### PR TITLE
Remove duplicated fields reference: auto_now and auto_now_add

### DIFF
--- a/docs/docs/models-and-databases/reference/fields.md
+++ b/docs/docs/models-and-databases/reference/fields.md
@@ -64,14 +64,6 @@ A `bool` field allows persisting booleans.
 
 A `date` field allows persisting date values, which map to `Time` objects in Crystal. In addition to the [common field options](#common-field-options), such fields support the following arguments:
 
-#### `auto_now`
-
-The `auto_now` argument allows ensuring that the corresponding field value is automatically set to the current time every time a record is saved. This provides a convenient way to define `updated_at` fields. Defaults to `false`.
-
-#### `auto_now_add`
-
-The `auto_now_add` argument allows ensuring that the corresponding field value is automatically set to the current time every time a record is created. This provides a convenient way to define `created_at` fields. Defaults to `false`.
-
 ### `date_time`
 
 A `date_time` field allows persisting date-time values, which map to `Time` objects in Crystal. In addition to the [common field options](#common-field-options), such fields support the following arguments:


### PR DESCRIPTION
Remove duplicated reference documentation for fields `auto_now` and `auto_now_add`.