### PR TITLE
Add support for split and join template filters #63

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@
 /spec/assets/
 /spec/media/
 /spec/marten/cli/manage/command/new_spec
+
+.*.swp

--- a/docs/docs/templates/reference/filters.md
+++ b/docs/docs/templates/reference/filters.md
@@ -41,6 +41,18 @@ For example:
 
 If `value` is "Hello", then the output will be "hello".
 
+## `join`
+
+The `join` filter converts an array of elements into a string separated by `arg`.
+
+For example:
+
+```html
+{{ value|join: arg }}
+```
+
+If `value` is `["Bananas","Apples","Oranges"]` and `arg` is `, `, then the output will be "Bananas, Apples, Oranges".
+
 ## `linebreaks`
 
 The `linebreaks` filter allows to convert a string replacing all newlines with HTML line breaks (`<br />`).
@@ -76,6 +88,18 @@ For example:
 ```
 
 If `value` is `hello`, then the output will be 5.
+
+## `split`
+
+The `split` filter converts a string into an array of elements separated by `arg`.
+
+For example:
+
+```html
+{{ value|split: arg }}
+```
+
+If `value` is `Bananas,Apples,Oranges` and `arg` is `,`, then the output will be ["Bananas","Apples","Oranges"].
 
 ## `upcase`
 

--- a/spec/marten/template/filter/join_spec.cr
+++ b/spec/marten/template/filter/join_spec.cr
@@ -10,7 +10,7 @@ describe Marten::Template::Filter::Join do
         Marten::Template::Value.from(", ")).should eq "42"
       expect_raises(Marten::Template::Errors::UnsupportedType) do
         filter.apply(Marten::Template::Value.from(42),
-                   Marten::Template::Value.from(", "))
+          Marten::Template::Value.from(", "))
       end
     end
   end

--- a/spec/marten/template/filter/join_spec.cr
+++ b/spec/marten/template/filter/join_spec.cr
@@ -1,0 +1,13 @@
+require "./spec_helper"
+
+describe Marten::Template::Filter::Join do
+  describe "#apply" do
+    it "returns the string joined version of the array of values" do
+      filter = Marten::Template::Filter::Join.new
+      filter.apply(Marten::Template::Value.from(["Banana","Orange","Apple"]), 
+                   Marten::Template::Value.from(", ")).should eq "Banana, Orange, Apple"
+      filter.apply(Marten::Template::Value.from([42]), 
+                   Marten::Template::Value.from(", ")).should eq "42"
+    end
+  end
+end

--- a/spec/marten/template/filter/join_spec.cr
+++ b/spec/marten/template/filter/join_spec.cr
@@ -4,10 +4,10 @@ describe Marten::Template::Filter::Join do
   describe "#apply" do
     it "returns the string joined version of the array of values" do
       filter = Marten::Template::Filter::Join.new
-      filter.apply(Marten::Template::Value.from(["Banana","Orange","Apple"]), 
-                   Marten::Template::Value.from(", ")).should eq "Banana, Orange, Apple"
-      filter.apply(Marten::Template::Value.from([42]), 
-                   Marten::Template::Value.from(", ")).should eq "42"
+      filter.apply(Marten::Template::Value.from(["Banana", "Orange", "Apple"]),
+        Marten::Template::Value.from(", ")).should eq "Banana, Orange, Apple"
+      filter.apply(Marten::Template::Value.from([42]),
+        Marten::Template::Value.from(", ")).should eq "42"
     end
   end
 end

--- a/spec/marten/template/filter/join_spec.cr
+++ b/spec/marten/template/filter/join_spec.cr
@@ -8,6 +8,10 @@ describe Marten::Template::Filter::Join do
         Marten::Template::Value.from(", ")).should eq "Banana, Orange, Apple"
       filter.apply(Marten::Template::Value.from([42]),
         Marten::Template::Value.from(", ")).should eq "42"
+      expect_raises(Marten::Template::Errors::UnsupportedType) do
+        filter.apply(Marten::Template::Value.from(42),
+                   Marten::Template::Value.from(", "))
+      end
     end
   end
 end

--- a/spec/marten/template/filter/split_spec.cr
+++ b/spec/marten/template/filter/split_spec.cr
@@ -1,0 +1,15 @@
+require "./spec_helper"
+
+describe Marten::Template::Filter::Split do
+  describe "#apply" do
+    it "returns the split array representation of the string" do
+      filter = Marten::Template::Filter::Split.new
+      filter.apply(Marten::Template::Value.from("Banana,Orange,Apple"), 
+                   Marten::Template::Value.from(",")).should eq ["Banana","Orange","Apple"]
+      filter.apply(Marten::Template::Value.from("Banana"),
+                   Marten::Template::Value.from(",")).should eq ["Banana"]
+      filter.apply(Marten::Template::Value.from(42),
+                   Marten::Template::Value.from(",")).should eq ["42"]
+    end
+  end
+end

--- a/spec/marten/template/filter/split_spec.cr
+++ b/spec/marten/template/filter/split_spec.cr
@@ -4,12 +4,12 @@ describe Marten::Template::Filter::Split do
   describe "#apply" do
     it "returns the split array representation of the string" do
       filter = Marten::Template::Filter::Split.new
-      filter.apply(Marten::Template::Value.from("Banana,Orange,Apple"), 
-                   Marten::Template::Value.from(",")).should eq ["Banana","Orange","Apple"]
+      filter.apply(Marten::Template::Value.from("Banana,Orange,Apple"),
+        Marten::Template::Value.from(",")).should eq ["Banana", "Orange", "Apple"]
       filter.apply(Marten::Template::Value.from("Banana"),
-                   Marten::Template::Value.from(",")).should eq ["Banana"]
+        Marten::Template::Value.from(",")).should eq ["Banana"]
       filter.apply(Marten::Template::Value.from(42),
-                   Marten::Template::Value.from(",")).should eq ["42"]
+        Marten::Template::Value.from(",")).should eq ["42"]
     end
   end
 end

--- a/src/marten/template/filter.cr
+++ b/src/marten/template/filter.cr
@@ -27,9 +27,11 @@ module Marten
       register "capitalize", Capitalize
       register "default", Default
       register "downcase", DownCase
+      register "join", Join
       register "linebreaks", LineBreaks
       register "safe", Safe
       register "size", Size
+      register "split", Split
       register "upcase", UpCase
     end
   end

--- a/src/marten/template/filter/join.cr
+++ b/src/marten/template/filter/join.cr
@@ -3,11 +3,13 @@ module Marten
     module Filter
       # The "join" filter.
       #
-      # The "join" filter converts an array into a string with elements separated by `arg`.
+      # The "join" filter converts an enumerable into a string with elements separated by `arg`.
       class Join < Base
         def apply(value : Value, arg : Value? = nil) : Value
-          # Only work on array
-          return value if !value.raw.is_a?(Array)
+          # Only work on enumerable
+          if !value.raw.is_a?(Enumerable)
+            raise Errors::UnsupportedType.new("#{value.raw.class} objects can't be joined")
+          end
           if arg
             Value.from(value.to_a.map(&.to_s).join(arg.to_s))
           else

--- a/src/marten/template/filter/join.cr
+++ b/src/marten/template/filter/join.cr
@@ -9,9 +9,9 @@ module Marten
           # Only work on array
           return value if !value.raw.is_a?(Array)
           if arg
-            Value.from(value.to_a.map { |f| f.to_s }.join(arg.to_s))
+            Value.from(value.to_a.map(&.to_s).join(arg.to_s))
           else
-            Value.from(value.to_a.map { |f| f.to_s }.join)
+            Value.from(value.to_a.map(&.to_s).join)
           end
         end
       end

--- a/src/marten/template/filter/join.cr
+++ b/src/marten/template/filter/join.cr
@@ -1,0 +1,21 @@
+module Marten
+  module Template
+    module Filter
+      # The "join" filter.
+      #
+      # The "join" filter converts an array into a string with elements separated by `arg`.
+      class Join < Base
+        def apply(value : Value, arg : Value? = nil) : Value
+          # Only work on array
+          return value if !value.raw.is_a?(Array)
+          if arg
+            puts value.to_a.map{|f| f.to_s}.join(arg.to_s)
+            Value.from(value.to_a.map{|f| f.to_s}.join(arg.to_s))
+          else
+            Value.from(value.to_a.map{|f| f.to_s}.join)
+          end
+        end
+      end
+    end
+  end
+end

--- a/src/marten/template/filter/join.cr
+++ b/src/marten/template/filter/join.cr
@@ -9,10 +9,9 @@ module Marten
           # Only work on array
           return value if !value.raw.is_a?(Array)
           if arg
-            puts value.to_a.map{|f| f.to_s}.join(arg.to_s)
-            Value.from(value.to_a.map{|f| f.to_s}.join(arg.to_s))
+            Value.from(value.to_a.map { |f| f.to_s }.join(arg.to_s))
           else
-            Value.from(value.to_a.map{|f| f.to_s}.join)
+            Value.from(value.to_a.map { |f| f.to_s }.join)
           end
         end
       end

--- a/src/marten/template/filter/split.cr
+++ b/src/marten/template/filter/split.cr
@@ -1,0 +1,18 @@
+module Marten
+  module Template
+    module Filter
+      # The "split" filter.
+      #
+      # The "split" filter converts string elements separated by `arg` into an array.
+      class Split < Base
+        def apply(value : Value, arg : Value? = nil) : Value
+          if arg
+            Value.from(value.to_s.split(arg.to_s))
+          else
+            Value.from(value.to_s.split)
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
I've added two new filters, filter specs and additions to docs/filters to add the `join` and `split` filter functionality. My first contribution here, so please give brutal feedback (with a crystal, marten or general contributor lens).