### PR TITLE
Implement with tag for template

### DIFF
--- a/docs/docs/templates/reference/tags.md
+++ b/docs/docs/templates/reference/tags.md
@@ -257,3 +257,17 @@ For example:
 ```
 
 Would output `This should not be {{ processed }}.`.
+
+## `with`
+
+The `with` template tag assigns one or more variables inside a block. After the end of the block has been reached the block variables are no longer available.
+
+For example:
+
+```
+{% with x = 'Hello World', y = 1 %}
+  {{ x }} {{ y }}!
+{% endwith %}
+```
+
+Would output `Hello World 1!`.

--- a/spec/marten/template/tag/with_spec.cr
+++ b/spec/marten/template/tag/with_spec.cr
@@ -1,0 +1,129 @@
+require "./spec_helper"
+
+describe Marten::Template::Tag::With do
+  describe "::new" do
+    it "raises if the with block does not contain at least one assignment" do
+      parser = Marten::Template::Parser.new(
+        "test{% endwith %}"
+
+      )
+
+      expect_raises(
+        Marten::Template::Errors::InvalidSyntax,
+        "Malformed with tag:at least on assignment must be present"
+      ) do
+        Marten::Template::Tag::With.new(parser, "with x")
+      end
+    end
+  end
+
+    describe "#render" do
+      it "properly renders a simple with block" do
+        parser = Marten::Template::Parser.new(
+          <<-TEMPLATE
+          {{ x }}
+          {% endwith %}
+          TEMPLATE
+        )
+        tag = Marten::Template::Tag::With.new(parser, "with x=1")
+
+        tag.render(Marten::Template::Context.new).strip.should eq "1"
+      end
+    end
+
+      it "properly renders with multiple variables assigned" do
+        parser = Marten::Template::Parser.new(
+          <<-TEMPLATE
+          {{ x }} - {{ y }}
+          {% endwith %}
+          TEMPLATE
+        )
+        tag = Marten::Template::Tag::With.new(parser, "with x=1, y=2")
+
+        tag.render(Marten::Template::Context.new).strip.should eq "1 - 2"
+      end
+
+      it "raises if a variable was defined but not set" do
+        parser = Marten::Template::Parser.new(
+          <<-TEMPLATE
+          {{ x }}|{{ y }}
+          {% endwith %}
+          TEMPLATE
+        )
+        tag = Marten::Template::Tag::With.new(parser, "with x=1, y")
+
+        expect_raises(
+          Marten::Template::Errors::UnknownVariable,
+          "Failed lookup for attribute 'y'"
+        ) do
+          tag.render(Marten::Template::Context.new)
+        end
+      end
+
+      it "context for the variables is locally" do
+        parser = Marten::Template::Parser.new(
+          <<-TEMPLATE
+          {{ x }} - {{ y }}
+          {% endwith %}
+          TEMPLATE
+        )
+
+        context = Marten::Template::Context.new
+        tag = Marten::Template::Tag::With.new(parser, "with x=1, y=2")
+
+        tag.render(context)
+
+        context["x"]?.should eq nil
+        context["y"]?.should eq nil
+      end
+
+      it "use context variables as value" do
+        parser = Marten::Template::Parser.new(
+          <<-TEMPLATE
+          {{ x }}
+          {% endwith %}
+          TEMPLATE
+        )
+
+        tag = Marten::Template::Tag::With.new(parser, "with x = var")
+
+        context = Marten::Template::Context{"var" => "2"}
+        tag.render(context).strip.should eq "2"
+      end
+
+      it "shadows existing variables" do
+        parser = Marten::Template::Parser.new("")
+
+        context = Marten::Template::Context.new
+        Marten::Template::Tag::Assign.new(parser, "assign x = 'test'").render(context)
+
+        context["x"].should eq "test"
+
+        parser = Marten::Template::Parser.new(
+          <<-TEMPLATE
+          {{ y }} - {{ x }}
+          {% endwith %}
+          TEMPLATE
+        )
+
+        tag = Marten::Template::Tag::With.new(parser, "with y = x, x = 1")
+        tag.render(context).strip.should eq "test - 1"
+
+        context["x"].should eq "test"
+      end
+
+      it "order of assignments has an impact" do
+        parser = Marten::Template::Parser.new("")
+        context = Marten::Template::Context{"x" => "test"}
+
+        parser = Marten::Template::Parser.new(
+          <<-TEMPLATE
+          {{ y }} - {{ x }}
+          {% endwith %}
+          TEMPLATE
+        )
+
+        tag = Marten::Template::Tag::With.new(parser, "with x = 1, y = x")
+        tag.render(context).strip.should_not eq "test - 1"
+      end
+end

--- a/spec/marten/template/tag/with_spec.cr
+++ b/spec/marten/template/tag/with_spec.cr
@@ -9,7 +9,7 @@ describe Marten::Template::Tag::With do
 
       expect_raises(
         Marten::Template::Errors::InvalidSyntax,
-        "Malformed with tag:at least on assignment must be present"
+        "Malformed with tag:at least one assignment must be present"
       ) do
         Marten::Template::Tag::With.new(parser, "with x")
       end

--- a/spec/marten/template/tag/with_spec.cr
+++ b/spec/marten/template/tag/with_spec.cr
@@ -5,7 +5,6 @@ describe Marten::Template::Tag::With do
     it "raises if the with block does not contain at least one assignment" do
       parser = Marten::Template::Parser.new(
         "test{% endwith %}"
-
       )
 
       expect_raises(
@@ -17,113 +16,112 @@ describe Marten::Template::Tag::With do
     end
   end
 
-    describe "#render" do
-      it "properly renders a simple with block" do
-        parser = Marten::Template::Parser.new(
-          <<-TEMPLATE
+  describe "#render" do
+    it "properly renders a simple with block" do
+      parser = Marten::Template::Parser.new(
+        <<-TEMPLATE
           {{ x }}
           {% endwith %}
           TEMPLATE
-        )
-        tag = Marten::Template::Tag::With.new(parser, "with x=1")
+      )
+      tag = Marten::Template::Tag::With.new(parser, "with x=1")
 
-        tag.render(Marten::Template::Context.new).strip.should eq "1"
-      end
+      tag.render(Marten::Template::Context.new).strip.should eq "1"
     end
+  end
 
-      it "properly renders with multiple variables assigned" do
-        parser = Marten::Template::Parser.new(
-          <<-TEMPLATE
+  it "properly renders with multiple variables assigned" do
+    parser = Marten::Template::Parser.new(
+      <<-TEMPLATE
           {{ x }} - {{ y }}
           {% endwith %}
           TEMPLATE
-        )
-        tag = Marten::Template::Tag::With.new(parser, "with x=1, y=2")
+    )
+    tag = Marten::Template::Tag::With.new(parser, "with x=1, y=2")
 
-        tag.render(Marten::Template::Context.new).strip.should eq "1 - 2"
-      end
+    tag.render(Marten::Template::Context.new).strip.should eq "1 - 2"
+  end
 
-      it "raises if a variable was defined but not set" do
-        parser = Marten::Template::Parser.new(
-          <<-TEMPLATE
+  it "raises if a variable was defined but not set" do
+    parser = Marten::Template::Parser.new(
+      <<-TEMPLATE
           {{ x }}|{{ y }}
           {% endwith %}
           TEMPLATE
-        )
-        tag = Marten::Template::Tag::With.new(parser, "with x=1, y")
+    )
+    tag = Marten::Template::Tag::With.new(parser, "with x=1, y")
 
-        expect_raises(
-          Marten::Template::Errors::UnknownVariable,
-          "Failed lookup for attribute 'y'"
-        ) do
-          tag.render(Marten::Template::Context.new)
-        end
-      end
+    expect_raises(
+      Marten::Template::Errors::UnknownVariable,
+      "Failed lookup for attribute 'y'"
+    ) do
+      tag.render(Marten::Template::Context.new)
+    end
+  end
 
-      it "context for the variables is locally" do
-        parser = Marten::Template::Parser.new(
-          <<-TEMPLATE
+  it "context for the variables is locally" do
+    parser = Marten::Template::Parser.new(
+      <<-TEMPLATE
           {{ x }} - {{ y }}
           {% endwith %}
           TEMPLATE
-        )
+    )
 
-        context = Marten::Template::Context.new
-        tag = Marten::Template::Tag::With.new(parser, "with x=1, y=2")
+    context = Marten::Template::Context.new
+    tag = Marten::Template::Tag::With.new(parser, "with x=1, y=2")
 
-        tag.render(context)
+    tag.render(context)
 
-        context["x"]?.should eq nil
-        context["y"]?.should eq nil
-      end
+    context["x"]?.should eq nil
+    context["y"]?.should eq nil
+  end
 
-      it "use context variables as value" do
-        parser = Marten::Template::Parser.new(
-          <<-TEMPLATE
+  it "use context variables as value" do
+    parser = Marten::Template::Parser.new(
+      <<-TEMPLATE
           {{ x }}
           {% endwith %}
           TEMPLATE
-        )
+    )
 
-        tag = Marten::Template::Tag::With.new(parser, "with x = var")
+    tag = Marten::Template::Tag::With.new(parser, "with x = var")
 
-        context = Marten::Template::Context{"var" => "2"}
-        tag.render(context).strip.should eq "2"
-      end
+    context = Marten::Template::Context{"var" => "2"}
+    tag.render(context).strip.should eq "2"
+  end
 
-      it "shadows existing variables" do
-        parser = Marten::Template::Parser.new("")
+  it "shadows existing variables" do
+    parser = Marten::Template::Parser.new("")
 
-        context = Marten::Template::Context.new
-        Marten::Template::Tag::Assign.new(parser, "assign x = 'test'").render(context)
+    context = Marten::Template::Context.new
+    Marten::Template::Tag::Assign.new(parser, "assign x = 'test'").render(context)
 
-        context["x"].should eq "test"
+    context["x"].should eq "test"
 
-        parser = Marten::Template::Parser.new(
-          <<-TEMPLATE
+    parser = Marten::Template::Parser.new(
+      <<-TEMPLATE
           {{ y }} - {{ x }}
           {% endwith %}
           TEMPLATE
-        )
+    )
 
-        tag = Marten::Template::Tag::With.new(parser, "with y = x, x = 1")
-        tag.render(context).strip.should eq "test - 1"
+    tag = Marten::Template::Tag::With.new(parser, "with y = x, x = 1")
+    tag.render(context).strip.should eq "test - 1"
 
-        context["x"].should eq "test"
-      end
+    context["x"].should eq "test"
+  end
 
-      it "order of assignments has an impact" do
-        parser = Marten::Template::Parser.new("")
-        context = Marten::Template::Context{"x" => "test"}
+  it "order of assignments has an impact" do
+    context = Marten::Template::Context{"x" => "test"}
 
-        parser = Marten::Template::Parser.new(
-          <<-TEMPLATE
+    parser = Marten::Template::Parser.new(
+      <<-TEMPLATE
           {{ y }} - {{ x }}
           {% endwith %}
           TEMPLATE
-        )
+    )
 
-        tag = Marten::Template::Tag::With.new(parser, "with x = 1, y = x")
-        tag.render(context).strip.should_not eq "test - 1"
-      end
+    tag = Marten::Template::Tag::With.new(parser, "with x = 1, y = x")
+    tag.render(context).strip.should_not eq "test - 1"
+  end
 end

--- a/spec/marten/template/tag/with_spec.cr
+++ b/spec/marten/template/tag/with_spec.cr
@@ -59,7 +59,7 @@ describe Marten::Template::Tag::With do
     end
   end
 
-  it "context for the variables is locally" do
+  it "does not pollute the outer context with local variables" do
     parser = Marten::Template::Parser.new(
       <<-TEMPLATE
           {{ x }} - {{ y }}

--- a/spec/marten/template/tag_spec.cr
+++ b/spec/marten/template/tag_spec.cr
@@ -3,7 +3,7 @@ require "./spec_helper"
 describe Marten::Template::Tag do
   describe "::get" do
     it "returns the right built-in tag classes for the expected tag names" do
-      Marten::Template::Tag.registry.size.should eq 17
+      Marten::Template::Tag.registry.size.should eq 18
       Marten::Template::Tag.get("asset").should eq Marten::Template::Tag::Asset
       Marten::Template::Tag.get("assign").should eq Marten::Template::Tag::Assign
       Marten::Template::Tag.get("block").should eq Marten::Template::Tag::Block
@@ -21,6 +21,7 @@ describe Marten::Template::Tag do
       Marten::Template::Tag.get("t").should eq Marten::Template::Tag::Translate
       Marten::Template::Tag.get("url").should eq Marten::Template::Tag::Url
       Marten::Template::Tag.get("verbatim").should eq Marten::Template::Tag::Verbatim
+      Marten::Template::Tag.get("with").should eq Marten::Template::Tag::With
     end
 
     it "returns a registered tag class for a given name string" do

--- a/src/marten/template/tag.cr
+++ b/src/marten/template/tag.cr
@@ -41,6 +41,7 @@ module Marten
       register "t", Translate
       register "url", Url
       register "verbatim", Verbatim
+      register "with", With
     end
   end
 end

--- a/src/marten/template/tag/with.cr
+++ b/src/marten/template/tag/with.cr
@@ -1,0 +1,49 @@
+require "./concerns/*"
+
+module Marten
+  module Template
+    module Tag
+      # The `with` template tag.
+      #
+      # The `with` template tag allows to assign local variables inside a block.
+      # After the block is done the assigned variables are no longer available.
+      # block:
+      #
+      # ```
+      # {% with var1=2(, var2="Hello World") %}
+      #   {{ var1 }} {{ var2 }}
+      # {% endwith %}
+      # ```
+      class With < Base
+        include CanExtractAssignments
+
+        @assignments : Array(Tuple(String, String))
+        @with_nodes : NodeSet
+
+        def initialize(parser : Parser, source : String)
+          @assignments = extract_assignments(source)
+          @with_nodes = parser.parse(up_to: {"endwith"})
+          parser.shift_token
+
+          if @assignments.size == 0
+            raise Errors::InvalidSyntax.new(
+              "Malformed with tag:at least on assignment must be present"
+            )
+          end
+        end
+
+        def render(context : Context) : String
+          context.stack do |with_context|
+            String.build do |io|
+              @assignments.each do |assignment|
+                context[assignment[0]] = FilterExpression.new(assignment.[1]).resolve(context)
+              end
+
+              io << @with_nodes.render(with_context)
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
I've added a `with` tag to assign variables locally within the template.

I'm not quite sure about the last test case if the order should matters.  Maybe it would be better to first look in the context if any variable name is already defined and shadow the outer variable only after assignment was done.

Closes #86 