### PR TITLE
Add --database to new command

### DIFF
--- a/docs/docs/development/reference/management-commands.md
+++ b/docs/docs/development/reference/management-commands.md
@@ -113,6 +113,7 @@ The command allows you to fully define the name of your project or application, 
 
 * `-d DIR, --dir=DIR` - An optional destination directory
 * `--with-auth` - Adds an authentication application to newly created projects. See [Authentication](../../authentication) to learn more about this capability
+* `--database` - Configure database. Currently MySql, Postgresql and Sqlite3 are supported. See [Database settings](../settings#database-settings) for more information.
 
 ### Arguments
 

--- a/docs/docs/development/reference/management-commands.md
+++ b/docs/docs/development/reference/management-commands.md
@@ -113,7 +113,7 @@ The command allows you to fully define the name of your project or application, 
 
 * `-d DIR, --dir=DIR` - An optional destination directory
 * `--with-auth` - Adds an authentication application to newly created projects. See [Authentication](../../authentication) to learn more about this capability
-* `--database` - Configure database. Currently MySql, Postgresql and Sqlite3 are supported. See [Database settings](../settings#database-settings) for more information.
+* `--database` - Configures the applications database. Currently MySql, Postgresql and Sqlite3 are supported. See [Database settings](../settings#database-settings) for more information.
 
 ### Arguments
 

--- a/docs/docs/development/reference/management-commands.md
+++ b/docs/docs/development/reference/management-commands.md
@@ -113,7 +113,7 @@ The command allows you to fully define the name of your project or application, 
 
 * `-d DIR, --dir=DIR` - An optional destination directory
 * `--with-auth` - Adds an authentication application to newly created projects. See [Authentication](../../authentication) to learn more about this capability
-* `--database` - Configures the applications database. Currently MySql, Postgresql and Sqlite3 are supported. See [Database settings](../settings#database-settings) for more information.
+* `--database` - Configures the applications database. Currently `mysql`, `postgresq` and `sqlite3` are supported. See [Database settings](../settings#database-settings) for more information.
 
 ### Arguments
 

--- a/spec/marten/cli/manage/command/new_spec.cr
+++ b/spec/marten/cli/manage/command/new_spec.cr
@@ -103,7 +103,7 @@ describe Marten::CLI::Manage::Command::New do
     end
 
     it "uses the interactive mode to create an app when no name is specified" do
-      stdin = IO::Memory.new("dummy_app\nsqlite3")
+      stdin = IO::Memory.new("dummy_app")
       stdout = IO::Memory.new
       stderr = IO::Memory.new
 
@@ -121,7 +121,7 @@ describe Marten::CLI::Manage::Command::New do
       output.includes?("Structure type ('project or 'app'):").should be_false
       output.includes?("App name:").should be_true
       output.includes?("Include authentication [yes/no]?").should be_false
-      output.includes?("Database:").should be_true
+      output.includes?("Database:").should be_false
 
       Marten::CLI::Manage::Command::NewSpec::APP_FILES.each do |path|
         File.exists?(File.join(".", "dummy_app", path)).should be_true, "File #{path} does not exist"

--- a/src/marten/cli/manage/command/new.cr
+++ b/src/marten/cli/manage/command/new.cr
@@ -198,9 +198,9 @@ module Marten
             template "project/src/auth/routes.cr.ecr", "src/auth/routes.cr"
           end
 
-          private NAME_RE      = /^[-a-zA-Z0-9_]+$/
-          private TYPE_APP     = "app"
-          private TYPE_PROJECT = "project"
+          private NAME_RE             = /^[-a-zA-Z0-9_]+$/
+          private TYPE_APP            = "app"
+          private TYPE_PROJECT        = "project"
           private SUPPORTED_DATABASES = {"sqlite3", "postgresql", "mysql"}
 
           private getter dir
@@ -259,10 +259,7 @@ module Marten
 
             print(style("\nDatabase:", mode: :bold), ending: " ")
             @database = stdin.gets.to_s.downcase.strip
-
-            if @database.empty?
-              @database = "sqlite3"
-            end
+            @database = "sqlite3" if @database.empty?
 
             if !database_valid?
               print(invalid_database_engine_error_message)

--- a/src/marten/cli/manage/command/new.cr
+++ b/src/marten/cli/manage/command/new.cr
@@ -9,9 +9,6 @@ module Marten
           TEMPLATE_DIR = "#{__DIR__}/new/templates"
 
           # :nodoc:
-          SUPPORTED_DATABASES = {"sqlite3", "postgresql", "mysql"}
-
-          # :nodoc:
           TPL_ = {} of Nil => Nil
 
           help "Initialize a new Marten project or application structure."
@@ -59,7 +56,7 @@ module Marten
               return
             end
 
-            ask_for_database if interactive_mode?
+            ask_for_database if interactive_mode? && !app?
             if !database_valid?
               print_error(invalid_database_engine_error_message)
               return
@@ -204,6 +201,7 @@ module Marten
           private NAME_RE      = /^[-a-zA-Z0-9_]+$/
           private TYPE_APP     = "app"
           private TYPE_PROJECT = "project"
+          private SUPPORTED_DATABASES = {"sqlite3", "postgresql", "mysql"}
 
           private getter dir
           private getter name

--- a/src/marten/cli/manage/command/new.cr
+++ b/src/marten/cli/manage/command/new.cr
@@ -37,7 +37,7 @@ module Marten
             on_option_with_arg(
               :database,
               arg: "db",
-              description: "Configure for default database (options: mysql/postgresql/sqlite3)") do |db|
+              description: "Configure default database (options: mysql/postgresql/sqlite3)") do |db|
               @database = db
             end
           end

--- a/src/marten/cli/manage/command/new/context.cr
+++ b/src/marten/cli/manage/command/new/context.cr
@@ -7,6 +7,7 @@ module Marten
             property dir : String
             property name : String
             property targets : Array(String)
+            property database : String
 
             TARGET_AUTH    = "auth"
             TARGET_GENERAL = "general"
@@ -14,6 +15,7 @@ module Marten
             def initialize(
               @dir = "example",
               @name = "example",
+              @database = "sqlite3",
               @targets = [TARGET_GENERAL]
             )
             end

--- a/src/marten/cli/manage/command/new/templates/project/config/settings/base.cr.ecr
+++ b/src/marten/cli/manage/command/new/templates/project/config/settings/base.cr.ecr
@@ -26,10 +26,28 @@ Marten.configure do |config|
 
   # Databases
   # https://martenframework.com/docs/development/reference/settings#database-settings
+  <%- if @context.database == "sqlite3" -%>
   config.database do |db|
     db.backend = :sqlite
     db.name = Path["<%= @context.name %>.db"].expand
   end
+  <%- elsif @context.database == "mysql" -%>
+  config.database do |db|
+    db.backend = :mysql
+    db.host = "localhost"
+    db.name = "<%= @context.name %>_db"
+    # db.user = "my_user"
+    # db.password = "my_passport"
+  end
+  <%- elsif @context.database == "postgresql" -%>
+  config.database do |db|
+    db.backend = :postgresql
+    db.host = "localhost"
+    db.name = "<%= @context.name %>_db"
+    # db.user = "my_user"
+    # db.password = "my_passport"
+  end
+  <%- end -%>
 
   # Templates context producers
   # https://martenframework.com/docs/development/reference/settings#context_producers

--- a/src/marten/cli/manage/command/new/templates/project/config/settings/base.cr.ecr
+++ b/src/marten/cli/manage/command/new/templates/project/config/settings/base.cr.ecr
@@ -37,7 +37,7 @@ Marten.configure do |config|
     db.host = "localhost"
     db.name = "<%= @context.name %>_db"
     # db.user = "my_user"
-    # db.password = "my_passport"
+    # db.password = "my_password"
   end
   <%- elsif @context.database == "postgresql" -%>
   config.database do |db|
@@ -45,7 +45,7 @@ Marten.configure do |config|
     db.host = "localhost"
     db.name = "<%= @context.name %>_db"
     # db.user = "my_user"
-    # db.password = "my_passport"
+    # db.password = "my_password"
   end
   <%- end -%>
 

--- a/src/marten/cli/manage/command/new/templates/project/shard.yml.ecr
+++ b/src/marten/cli/manage/command/new/templates/project/shard.yml.ecr
@@ -9,5 +9,13 @@ dependencies:
     github: martenframework/marten-auth
     version: ">= 0.2.0"
 <%- end -%>
+<%- if @context.database == "sqlite3"  -%>
   sqlite3:
     github: crystal-lang/crystal-sqlite3
+<%- elsif @context.database == "postgresql"  -%>
+  pg:
+    github: will/crystal-pg
+<%- elsif @context.database == "mysql"  -%>
+  mysql:
+    github: crystal-lang/crystal-mysql
+<%- end -%>


### PR DESCRIPTION
This commit adds the --database option to the new command.

By default when the option is not presented the sqlite3 database will be selected, otherwise the respective database which was choosen, i.e. the shard.yml file will be configured to include the shard for the specific database.

If MySql or Postgresql is selected the config/base.cr will use `localhost` as host and `<project_name>_db` as the database name. The user and password config will be written as a comment to `config/base.cr` as we can't make assumptions.

Closes #103 