### PR TITLE
Add command to remove expired sessions

### DIFF
--- a/docs/docs/development/management-commands.md
+++ b/docs/docs/development/management-commands.md
@@ -45,6 +45,7 @@ Usage: marten [command] [arguments]
 Available commands:
 
 [marten]
+  › clearsessions
   › collectassets
   › genmigrations
   › listmigrations

--- a/docs/docs/development/reference/management-commands.md
+++ b/docs/docs/development/reference/management-commands.md
@@ -6,6 +6,25 @@ toc_max_heading_level: 2
 
 This page provides a reference for all the available management commands and their options.
 
+## `clearsessions`
+
+**Usage:** `marten clearsessions [options]`
+
+Clears all expired sessions for the configured session store.
+
+Please refer to [Sessions](../../handlers-and-http/sessions.md) to learn more about sessions.
+
+### Options
+
+* `--no-input` - Does not show prompts to the user
+
+### Examples
+
+```bash
+marten clearsessions            # Clears all expired sessions
+marten clearsessions --no-input # Clears all expired sessions without any prompts
+```
+
 ## `collectassets`
 
 **Usage:** `marten collectassets [options]`

--- a/spec/marten/cli/manage/command/clearsessions.cr
+++ b/spec/marten/cli/manage/command/clearsessions.cr
@@ -1,0 +1,44 @@
+require "./spec_helper"
+
+describe Marten::CLI::Manage::Command::ClearSessions do
+  describe "#run" do
+    it "warns the user that the deleted sessions can't be restored" do
+      stdin = IO::Memory.new("")
+      stdout = IO::Memory.new
+
+      command = Marten::CLI::Manage::Command::ClearSessions.new(
+        options: [] of String,
+        stdin: stdin,
+        stdout: stdout
+      )
+
+      command.handle
+
+      stdout.rewind.gets_to_end.starts_with?(
+        "All expired sessions will be removed.\n" \
+        "These sessions can't be restored.\n" \
+        "Do you want to continue [yes/no]?"
+      ).should be_true
+    end
+
+    it "does not do anything if the user inputs that they does not want to proceed" do
+      stdin = IO::Memory.new("no")
+      stdout = IO::Memory.new
+
+      command = Marten::CLI::Manage::Command::ClearSessions.new(
+        options: [] of String,
+        stdin: stdin,
+        stdout: stdout
+      )
+
+      command.handle
+
+      stdout.rewind.gets_to_end.should eq(
+        "All expired sessions will be removed.\n" \
+        "These sessions can't be restored.\n" \
+        "Do you want to continue [yes/no]? " \
+        "Cancelling...\n"
+      )
+    end
+  end
+end

--- a/spec/marten/cli/manage/command/clearsessions.cr
+++ b/spec/marten/cli/manage/command/clearsessions.cr
@@ -40,5 +40,25 @@ describe Marten::CLI::Manage::Command::ClearSessions do
         "Cancelling...\n"
       )
     end
+
+    it "does not show prompt if -no-input is provided" do
+      stdin = IO::Memory.new("")
+      stdout = IO::Memory.new
+
+      command = Marten::CLI::Manage::Command::ClearSessions.new(
+        options: ["--no-input"] of String,
+        stdin: stdin,
+        stdout: stdout
+      )
+
+      command.handle
+
+      stdout.rewind.gets_to_end.should_not contain(
+        "All expired sessions will be removed.\n" \
+        "These sessions can't be restored.\n" \
+        "Do you want to continue [yes/no]? " \
+        "Cancelling...\n"
+      )
+    end
   end
 end

--- a/spec/marten/http/session/store/base_spec.cr
+++ b/spec/marten/http/session/store/base_spec.cr
@@ -255,6 +255,9 @@ module Marten::HTTP::Session::Store::BaseSpec
       {"foo" => "bar"}
     end
 
+    def clear_expired_entries : Nil
+    end
+
     def save : Nil
     end
   end

--- a/spec/marten/http/session/store_spec.cr
+++ b/spec/marten/http/session/store_spec.cr
@@ -56,6 +56,9 @@ module Marten::HTTP::Session::StoreSpec
       SessionHash.new
     end
 
+    def clear_expired_entries : Nil
+    end
+
     def save : Nil
     end
   end

--- a/src/marten/cli/manage/command/clearsessions.cr
+++ b/src/marten/cli/manage/command/clearsessions.cr
@@ -5,15 +5,16 @@ module Marten
         class ClearSessions < Base
           command_name :clearsessions
           help "Clears all expired sessions."
+          getter no_input
 
-          @no_prompt : Bool = false
+          @no_input : Bool = false
 
           def setup
-            on_option("-y", "Do not show prompts to the user") { @no_prompt = true }
+            on_option("no-input", "Do not show prompts to the user") { @no_input = true }
           end
 
           def run
-            unless no_prompt?
+            unless no_input
               print("All expired sessions will be removed.")
               print("These sessions can't be restored.")
               print("Do you want to continue [yes/no]?", ending: " ")
@@ -25,14 +26,8 @@ module Marten
 
             print(style("Clearing expired sessions", fore: :light_blue, mode: :bold), ending: "\n")
 
-            HTTP::Session::Store.registry.each_value do |session_store_klass|
-              store = session_store_klass.new(nil)
-              store.clear_expired_entries
-            end
-          end
-
-          private def no_prompt?
-            @no_prompt
+            session_store_klass = HTTP::Session::Store.get(Marten.settings.sessions.store)
+            session_store_klass.new(nil).clear_expired_entries
           end
         end
       end

--- a/src/marten/cli/manage/command/clearsessions.cr
+++ b/src/marten/cli/manage/command/clearsessions.cr
@@ -1,0 +1,41 @@
+module Marten
+  module CLI
+    class Manage
+      module Command
+        class ClearSessions < Base
+          command_name :clearsessions
+          help "Clears all expired sessions."
+
+          @no_prompt : Bool = false
+
+          def setup
+            on_option("-y", "Do not show prompts to the user") { @no_prompt = true }
+          end
+
+          def run
+            unless no_prompt?
+              print("All expired sessions will be removed.")
+              print("These sessions can't be restored.")
+              print("Do you want to continue [yes/no]?", ending: " ")
+              unless %w(y yes).includes?(stdin.gets.to_s.downcase)
+                print("Cancelling...")
+                return
+              end
+            end
+
+            print(style("Clearing expired sessions", fore: :light_blue, mode: :bold), ending: "\n")
+
+            HTTP::Session::Store.registry.each_value do |session_store_klass|
+              store = session_store_klass.new(nil)
+              store.clear_expired_entries
+            end
+          end
+
+          private def no_prompt?
+            @no_prompt
+          end
+        end
+      end
+    end
+  end
+end

--- a/src/marten/http/session/store/base.cr
+++ b/src/marten/http/session/store/base.cr
@@ -98,6 +98,8 @@ module Marten
           # Saves the session store data.
           abstract def save : Nil
 
+          abstract def clear_expired_entries : Nil
+
           private def session_hash
             @session_hash ||= begin
               @accessed = true

--- a/src/marten/http/session/store/cookie.cr
+++ b/src/marten/http/session/store/cookie.cr
@@ -28,6 +28,9 @@ module Marten
             @session_key = encryptor.encrypt(session_hash.to_json)
           end
 
+          def clear_expired_entries : Nil
+          end
+
           private def encryptor
             @encryptor ||= Core::Encryptor.new
           end


### PR DESCRIPTION
Adds a new abstract method `clear_expired_entries` to `Marten::HTTP::Session::Store::Base`.

Additionally a new CLI command clearsessions was added, which calls `clear_expired_entries` on all registered session stores