### PR TITLE
Add callbacks to schema handler

### DIFF
--- a/docs/docs/handlers-and-http/generic-handlers.md
+++ b/docs/docs/handlers-and-http/generic-handlers.md
@@ -140,19 +140,19 @@ By default, such a handler will render the configured template when the incoming
 
 If the schema is valid, a temporary redirect is issued by using the URL corresponding to the `#success_route_name` value (although it should be noted that the way to generate this success URL can be overridden by defining a `#success_url` method). By default, the handler does nothing when the processed schema is valid (except redirecting to the success URL).
 
-
 #### Callbacks
 
 Callbacks let you define logics that are triggered before or after the validation of the schema. This allows you to easily intercept validation
-and handle the response independently of the schema validty. Two callbacks are supported: `before_schema_validation`, `after_schema_validation`,
+and handle the response independently of the schema validity. Four callbacks are supported: `before_schema_validation`, `after_schema_validation`,
 `after_successful_schema_validation` and `after_failed_schema_validation`.
 
-All callbacks can optionally return a [`Marten::HTTP::Response`](pathname:///api/dev/Marten/HTTP/Response.html). When a HTTP response is returned
-all pending callbacks and the success/fail response are skipped.
+All callbacks can optionally return a [`Marten::HTTP::Response`](pathname:///api/dev/Marten/HTTP/Response.html). When a HTTP response is returned,
+all following callbacks are skipped and the obtained response is returned directly, thus bypassing responses that might have been
+returned after by the handler.
 
 ##### `before_schema_validation`
 
-`before_schema_validation` callbacks are executed _before_ a schema is checked for validty.
+`before_schema_validation` callbacks are executed _before_ a schema is checked for validity.
 For example, this capability can be leveraged to inspect the incoming request and verify that a user is logged in:
 
 ```crystal
@@ -170,7 +170,7 @@ end
 
 ##### `after_schema_validation`
 
-`after_schema_validation` callbacks are executed right _after_ a schema is checked for validty.
+`after_schema_validation` callbacks are executed right _after_ a schema is checked for validity.
 For example, this capability can be leveraged to add additional cookies to the response:
 
 ```crystal
@@ -188,8 +188,7 @@ end
 
 ##### `after_successful_schema_validation`
 
-`after_successful_schema_validation` callbacks are executed right _after_ a schema is checked for validty and the
-`after_schema_validation` callbacks, but only if the schema wasn't valid.
+`after_successful_schema_validation` callbacks are executed right _after_ a schema is checked for validity (and after possible `after_schema_validation` callbacks), and only if the schema validation was successful.
 For example, this capability can be leveraged to add additional cookies to the response:
 
 ```crystal
@@ -207,8 +206,8 @@ end
 
 ##### `after_failed_schema_validation`
 
-`after_failed_schema_validation` callbacks are executed right _after_ a schema is checked for validty and the
-`after_schema_validation` callbacks, but only if the schema was valid.
+`after_failed_schema_validation` callbacks are executed right _after_ a schema is checked for validity (and after possible
+`after_schema_validation` callbacks), but only if the schema validation failed.
 For example, this capability can be leveraged to add additional cookies to the response:
 
 ```crystal

--- a/spec/marten/handlers/schema_spec.cr
+++ b/spec/marten/handlers/schema_spec.cr
@@ -220,7 +220,7 @@ describe Marten::Handlers::Schema do
     end
   end
 
-  describe "callbacks" do
+  describe "#post" do
     it "executes success callback" do
       request = Marten::HTTP::Request.new(
         ::HTTP::Request.new(
@@ -451,21 +451,6 @@ module Marten::Handlers::SchemaSpec
 
     private def set_foobar
       self.foobar = "set_foobar"
-    end
-  end
-
-  class TestHandlerWithBeforeValidateResponse < Marten::Handlers::Schema
-    before_schema_validation :return_before_schema_validation_response
-    success_url "https://example.com"
-    template_name "specs/handlers/schema/test.html"
-    schema TestSchema
-
-    def get
-      Marten::HTTP::Response.new("Regular response", content_type: "text/plain", status: 200)
-    end
-
-    private def return_before_schema_validation_response
-      Marten::HTTP::Response.new("before_schema_validation response", content_type: "text/plain", status: 200)
     end
   end
 

--- a/spec/marten/handlers/schema_spec/empty_schema.cr
+++ b/spec/marten/handlers/schema_spec/empty_schema.cr
@@ -1,0 +1,4 @@
+module Marten::Handlers::SchemaSpec
+  class EmptySchema < Marten::Schema
+  end
+end

--- a/spec/marten/handlers/schema_spec/test_schema.cr
+++ b/spec/marten/handlers/schema_spec/test_schema.cr
@@ -3,7 +3,4 @@ module Marten::Handlers::SchemaSpec
     field :foo, :string
     field :bar, :string
   end
-
-  class EmptySchema < Marten::Schema
-  end
 end

--- a/src/marten/handlers/schema.cr
+++ b/src/marten/handlers/schema.cr
@@ -1,5 +1,5 @@
 require "./concerns/record_listing"
-require "./concerns/schema_callbacks"
+require "./schema/callbacks"
 require "./template"
 
 module Marten
@@ -79,10 +79,12 @@ module Marten
 
       def post
         @response = run_before_validation_callbacks
+        return response! if !@response.nil?
 
         valid_schema = schema.valid?
 
         @response ||= run_after_validation_callbacks
+        return response! if !@response.nil?
 
         if valid_schema
           @response ||= run_after_successful_validation_callbacks

--- a/src/marten/handlers/schema/callbacks.cr
+++ b/src/marten/handlers/schema/callbacks.cr
@@ -4,7 +4,7 @@ module Marten
     #
     # This module provides the ability to define callbacks that are executed before, after, after success or/and after
     # failed validation of a schema.
-    # They allow to intercept the incoming request and to return early HTTP responses. TwFouro hooks
+    # They allow to intercept the incoming request and to return early HTTP responses. Four hooks
     # are enabled by the use of this module:
     # - `before_schema_validation` callbacks are executed before the validation of the schema
     # - `after_schema_validation` callbacks are executed right after the validation of the schema
@@ -29,11 +29,11 @@ module Marten
         end
       end
 
-      # Allows to do define callbacks that are called after executing `Marten::Schema#valid?`.
+      # Allows to define callbacks that are called before validating the schema.
       #
       # Those callbacks have access to the incoming `#request` object and they can return a custom HTTP response.
       # If one of such callbacks returns a custom HTTP response, the following callbacks will be skipped and this
-      # custom response will be returned by the handler instead of the success or fail HTTP response.
+      # custom response will be returned by the handler right away.
       macro before_schema_validation(*names)
           {%
             names.reduce(VALIDATION_CALLBACKS[:before_validation]) do |array, name|
@@ -43,11 +43,11 @@ module Marten
           %}
         end
 
-      # Allows to do define callbacks that are called after executing `Marten::Schema#valid?`.
+      # Allows to define callbacks that are called after validating the schema (whether it's valid or not).
       #
       # Those callbacks have access to the incoming `#request` object and they can return a custom HTTP response.
       # If one of such callbacks returns a custom HTTP response, the following callbacks will be skipped and this
-      # custom response will be returned by the handler instead of the success or fail HTTP response.
+      # custom response will be returned by the handler right away.
       macro after_schema_validation(*names)
           {%
             names.reduce(VALIDATION_CALLBACKS[:after_validation]) do |array, name|
@@ -57,11 +57,11 @@ module Marten
           %}
         end
 
-      # Allows to do define callbacks that are called after executing `Marten::Schema#valid?`.
+      # Allows to define callbacks that are called after a successful schema validation.
       #
       # Those callbacks have access to the incoming `#request` object and they can return a custom HTTP response.
       # If one of such callbacks returns a custom HTTP response, the following callbacks will be skipped and this
-      # custom response will be returned by the handler instead of the success or fail HTTP response.
+      # custom response will be returned by the handler right away.
       macro after_successful_schema_validation(*names)
           {%
             names.reduce(VALIDATION_CALLBACKS[:after_successful_validation]) do |array, name|
@@ -71,11 +71,11 @@ module Marten
           %}
         end
 
-      # Allows to do define callbacks that are called after executing `Marten::Schema#valid?`.
+      # Allows to define callbacks that are called after a failed schema validation.
       #
       # Those callbacks have access to the incoming `#request` object and they can return a custom HTTP response.
       # If one of such callbacks returns a custom HTTP response, the following callbacks will be skipped and
-      # this custom response will be returned by the handler instead of the success or fail HTTP response.
+      # this custom response will be returned by the handler right away.
       macro after_failed_schema_validation(*names)
           {%
             names.reduce(VALIDATION_CALLBACKS[:after_failed_validation]) do |array, name|


### PR DESCRIPTION
This commit adds the callbacks `before_schema_validation`, `after_schema_validation`, `after_successful_schema_validation` and `after_failed_schema_validation`.

Closes #111