### PR TITLE
Remove unncessary input field from password update form

### DIFF
--- a/src/marten/cli/templates/auth/templates/app/templates/password_update.html.ecr
+++ b/src/marten/cli/templates/auth/templates/app/templates/password_update.html.ecr
@@ -4,7 +4,6 @@
 <h1>Update password</h1>
 <form method="post" action="" enctype="multipart/form-data" novalidate>
   <input type="hidden" name="csrftoken" value="{% csrf_token %}" />
-  <input type="hidden" name="email" value="{{ request.user.email }}">
   {% for error in schema.errors.global %}<div class="global-error">{{ error.message }}</div>{% endfor %}
 
   <label for="{{ schema.old_password.id }}">Old password</label>


### PR DESCRIPTION
I accidentally added an unncessary email field to the password update form, which is not required