### PR TITLE
Use csrf session

### DIFF
--- a/docs/docs/development/reference/settings.md
+++ b/docs/docs/development/reference/settings.md
@@ -301,6 +301,16 @@ Default: `true`
 
 A boolean indicating if the CSRF protection is enabled globally. When set to `true`, handlers will automatically perform a CSRF check to protect unsafe requests (ie. requests whose methods are not `GET`, `HEAD`, `OPTIONS`, or `TRACE`). Regardless of the value of this setting, it is always possible to explicitly enable or disable CSRF protection on a per-handler basis. See [Cross-Site Request Forgery protection](../../security/csrf.md) for more details.
 
+### `session_name`
+
+Default: `"csrftoken"`
+
+The name of the session key to use for the CSRF token. This session key should be different than any other session key created by your application.
+
+:::info
+This value is only relevant if `use_session` is set to `true`.
+:::
+
 ### `trusted_origins`
 
 Default: `[] of String`
@@ -317,6 +327,13 @@ config.csrf.trusted_origins = [
   "https://other.example.org",
 ]
 ```
+
+### `use_session`
+
+Default: `false`
+
+A boolean indicating whether the CSRF token should be stored inside a session.
+If set to `true`, the CSRF token will be stored [in a session](../../handlers-and-http/sessions.md) rather than in a cookie.
 
 ## Content-Security-Policy settings
 

--- a/docs/docs/development/reference/settings.md
+++ b/docs/docs/development/reference/settings.md
@@ -301,7 +301,7 @@ Default: `true`
 
 A boolean indicating if the CSRF protection is enabled globally. When set to `true`, handlers will automatically perform a CSRF check to protect unsafe requests (ie. requests whose methods are not `GET`, `HEAD`, `OPTIONS`, or `TRACE`). Regardless of the value of this setting, it is always possible to explicitly enable or disable CSRF protection on a per-handler basis. See [Cross-Site Request Forgery protection](../../security/csrf.md) for more details.
 
-### `session_name`
+### `session_key`
 
 Default: `"csrftoken"`
 

--- a/spec/marten/conf/global_settings/csrf_spec.cr
+++ b/spec/marten/conf/global_settings/csrf_spec.cr
@@ -154,6 +154,33 @@ describe Marten::Conf::GlobalSettings::CSRF do
     end
   end
 
+  describe "#session_name" do
+    it "returns csrftoken by default" do
+      csrf_conf = Marten::Conf::GlobalSettings::CSRF.new
+      csrf_conf.session_name.should eq "csrftoken"
+    end
+
+    it "returns the configured value if applicable" do
+      csrf_conf = Marten::Conf::GlobalSettings::CSRF.new
+      csrf_conf.session_name = "custom_name"
+      csrf_conf.session_name.should eq "custom_name"
+    end
+  end
+
+  describe "#session_name=" do
+    it "allows to configure the session name from a string" do
+      csrf_conf = Marten::Conf::GlobalSettings::CSRF.new
+      csrf_conf.session_name = "custom_name"
+      csrf_conf.session_name.should eq "custom_name"
+    end
+
+    it "allows to configure the session name from a symbol" do
+      csrf_conf = Marten::Conf::GlobalSettings::CSRF.new
+      csrf_conf.session_name = :custom_name
+      csrf_conf.session_name.should eq "custom_name"
+    end
+  end
+
   describe "#trusted_origins" do
     it "returns an empty array by default" do
       csrf_conf = Marten::Conf::GlobalSettings::CSRF.new
@@ -172,6 +199,27 @@ describe Marten::Conf::GlobalSettings::CSRF do
       csrf_conf = Marten::Conf::GlobalSettings::CSRF.new
       csrf_conf.trusted_origins = ["https://*.example.com"]
       csrf_conf.trusted_origins.should eq ["https://*.example.com"]
+    end
+  end
+
+  describe "#use_session" do
+    it "returns false by default" do
+      csrf_conf = Marten::Conf::GlobalSettings::CSRF.new
+      csrf_conf.use_session.should be_false
+    end
+
+    it "returns the configured value if applicable" do
+      csrf_conf = Marten::Conf::GlobalSettings::CSRF.new
+      csrf_conf.use_session = true
+      csrf_conf.use_session.should be_true
+    end
+  end
+
+  describe "#use_session=" do
+    it "allows to store the CSRF token inside a session" do
+      csrf_conf = Marten::Conf::GlobalSettings::CSRF.new
+      csrf_conf.use_session = true
+      csrf_conf.use_session.should be_true
     end
   end
 end

--- a/spec/marten/conf/global_settings/csrf_spec.cr
+++ b/spec/marten/conf/global_settings/csrf_spec.cr
@@ -154,30 +154,30 @@ describe Marten::Conf::GlobalSettings::CSRF do
     end
   end
 
-  describe "#session_name" do
+  describe "#session_key" do
     it "returns csrftoken by default" do
       csrf_conf = Marten::Conf::GlobalSettings::CSRF.new
-      csrf_conf.session_name.should eq "csrftoken"
+      csrf_conf.session_key.should eq "csrftoken"
     end
 
     it "returns the configured value if applicable" do
       csrf_conf = Marten::Conf::GlobalSettings::CSRF.new
-      csrf_conf.session_name = "custom_name"
-      csrf_conf.session_name.should eq "custom_name"
+      csrf_conf.session_key = "custom_name"
+      csrf_conf.session_key.should eq "custom_name"
     end
   end
 
-  describe "#session_name=" do
+  describe "#session_key=" do
     it "allows to configure the session name from a string" do
       csrf_conf = Marten::Conf::GlobalSettings::CSRF.new
-      csrf_conf.session_name = "custom_name"
-      csrf_conf.session_name.should eq "custom_name"
+      csrf_conf.session_key = "custom_name"
+      csrf_conf.session_key.should eq "custom_name"
     end
 
     it "allows to configure the session name from a symbol" do
       csrf_conf = Marten::Conf::GlobalSettings::CSRF.new
-      csrf_conf.session_name = :custom_name
-      csrf_conf.session_name.should eq "custom_name"
+      csrf_conf.session_key = :custom_name
+      csrf_conf.session_key.should eq "custom_name"
     end
   end
 

--- a/spec/marten/handlers/concerns/request_forgery_protection_spec.cr
+++ b/spec/marten/handlers/concerns/request_forgery_protection_spec.cr
@@ -178,7 +178,7 @@ describe Marten::Handlers::RequestForgeryProtection do
       response.status.should eq 200
     end
 
-    it "allows unsafe requests if the csrftoken POST parameter is specified and matches the CSRF token stored in the session" do
+    it "allows unsafe requests if the csrftoken POST parameter is specified and matches the sessions CSRF token" do
       session_store = Marten::HTTP::Session::Store::Cookie.new("sessionkey")
       Marten.settings.csrf.use_session = true
 

--- a/spec/marten/handlers/concerns/request_forgery_protection_spec.cr
+++ b/spec/marten/handlers/concerns/request_forgery_protection_spec.cr
@@ -178,7 +178,7 @@ describe Marten::Handlers::RequestForgeryProtection do
       response.status.should eq 200
     end
 
-    it "allows unsafe requests if the csrftoken POST parameter is specified and matches the CSRF token cookie" do
+    it "allows unsafe requests if the csrftoken POST parameter is specified and matches the CSRF token stored in the session" do
       session_store = Marten::HTTP::Session::Store::Cookie.new("sessionkey")
       Marten.settings.csrf.use_session = true
 

--- a/src/marten/conf/global_settings/csrf.cr
+++ b/src/marten/conf/global_settings/csrf.cr
@@ -64,13 +64,13 @@ module Marten
         # Allows to set whether or not CSRF protection is enabled globally.
         setter protection_enabled
 
-        # Returns the name of the session to use for the CSRF token (defaults to `"csrftoken"`).
+        # Returns the session key to use for the CSRF token (defaults to `"csrftoken"`).
         getter session_key
 
         # Allows to set whether or not the CSRF token should be stored inside the session.
         setter use_session
 
-        # Allows to set the name of the session to use for the CSRF token.
+        # Allows to set session key to use for the CSRF token.
         def session_key=(name : String | Symbol)
           @session_key = name.to_s
         end

--- a/src/marten/conf/global_settings/csrf.cr
+++ b/src/marten/conf/global_settings/csrf.cr
@@ -11,7 +11,7 @@ module Marten
         @cookie_secure : Bool = false
         @protection_enabled : Bool = true
         @exactly_defined_trusted_origins : Array(String)? = nil
-        @session_name : String = "csrftoken"
+        @session_key : String = "csrftoken"
         @trusted_origins : Array(String) = [] of String
         @trusted_origins_hosts : Array(String)? = nil
         @trusted_origin_subdomains_per_scheme : Hash(String, Array(String))? = nil
@@ -65,14 +65,14 @@ module Marten
         setter protection_enabled
 
         # Returns the name of the session to use for the CSRF token (defaults to `"csrftoken"`).
-        getter session_name
+        getter session_key
 
         # Allows to set whether or not the CSRF token should be stored inside the session.
         setter use_session
 
         # Allows to set the name of the session to use for the CSRF token.
-        def session_name=(name : String | Symbol)
-          @session_name = name.to_s
+        def session_key=(name : String | Symbol)
+          @session_key = name.to_s
         end
 
         # Allows to set the name of the cookie to use for the CSRF token.

--- a/src/marten/conf/global_settings/csrf.cr
+++ b/src/marten/conf/global_settings/csrf.cr
@@ -11,9 +11,11 @@ module Marten
         @cookie_secure : Bool = false
         @protection_enabled : Bool = true
         @exactly_defined_trusted_origins : Array(String)? = nil
+        @session_name : String = "csrftoken"
         @trusted_origins : Array(String) = [] of String
         @trusted_origins_hosts : Array(String)? = nil
         @trusted_origin_subdomains_per_scheme : Hash(String, Array(String))? = nil
+        @use_session : Bool = false
 
         # Returns the domain to use when setting the CSRF cookie.
         getter cookie_domain
@@ -38,6 +40,9 @@ module Marten
         # Returns a boolean indicating if CSRF protection is enabled globally (defaults to `true`).
         getter protection_enabled
 
+        # Returns a boolean indicating if the CSRF token is stored inside the session.
+        getter use_session
+
         # Returns the array of CSRF-trusted origins.
         getter trusted_origins
 
@@ -58,6 +63,17 @@ module Marten
 
         # Allows to set whether or not CSRF protection is enabled globally.
         setter protection_enabled
+
+        # Returns the name of the session to use for the CSRF token (defaults to `"csrftoken"`).
+        getter session_name
+
+        # Allows to set whether or not the CSRF token should be stored inside the session.
+        setter use_session
+
+        # Allows to set the name of the session to use for the CSRF token.
+        def session_name=(name : String | Symbol)
+          @session_name = name.to_s
+        end
 
         # Allows to set the name of the cookie to use for the CSRF token.
         def cookie_name=(name : String | Symbol)

--- a/src/marten/handlers/concerns/request_forgery_protection.cr
+++ b/src/marten/handlers/concerns/request_forgery_protection.cr
@@ -97,7 +97,7 @@ module Marten
 
         token = begin
           if Marten.settings.csrf.use_session
-            request.session[Marten.settings.csrf.session_name]
+            request.session[Marten.settings.csrf.session_key]
           else
             request.cookies[Marten.settings.csrf.cookie_name]
           end
@@ -147,7 +147,7 @@ module Marten
         return unless csrf_token && csrf_token_update_required
 
         if Marten.settings.csrf.use_session
-          request.session[Marten.settings.csrf.session_name] = csrf_token.not_nil!
+          request.session[Marten.settings.csrf.session_key] = csrf_token.to_s
         else
           response!.cookies.set(
             name: Marten.settings.csrf.cookie_name,


### PR DESCRIPTION
This PR adds the option to store the CSRF token in a session. The session key is also changeable, but set to `csrftoken` by default.

Closes #66 