### PR TITLE
Return 422 on invalid form submit

### DIFF
--- a/spec/marten/handlers/record_create_spec.cr
+++ b/spec/marten/handlers/record_create_spec.cr
@@ -80,7 +80,7 @@ describe Marten::Handlers::RecordCreate do
       response = handler.post
 
       response.should be_a Marten::HTTP::Response
-      response.status.should eq 200
+      response.status.should eq 422
       response.content.includes?("Schema is invalid").should be_true
     end
   end

--- a/spec/marten/handlers/record_update_spec.cr
+++ b/spec/marten/handlers/record_update_spec.cr
@@ -99,7 +99,7 @@ describe Marten::Handlers::RecordUpdate do
       response = handler.post
 
       response.should be_a Marten::HTTP::Response
-      response.status.should eq 200
+      response.status.should eq 422
       response.content.includes?("Schema is invalid").should be_true
       tag.reload.name.should eq "oldtag"
     end

--- a/spec/marten/handlers/schema_spec.cr
+++ b/spec/marten/handlers/schema_spec.cr
@@ -109,7 +109,7 @@ describe Marten::Handlers::Schema do
       response = handler.post
 
       response.should be_a Marten::HTTP::Response
-      response.status.should eq 200
+      response.status.should eq 422
       response.content.includes?("Schema is invalid").should be_true
     end
   end
@@ -130,7 +130,7 @@ describe Marten::Handlers::Schema do
       response = handler.process_invalid_schema
 
       response.should be_a Marten::HTTP::Response
-      response.status.should eq 200
+      response.status.should eq 422
       response.content.includes?("Schema is invalid").should be_true
     end
   end
@@ -187,7 +187,7 @@ describe Marten::Handlers::Schema do
       response = handler.put
 
       response.should be_a Marten::HTTP::Response
-      response.status.should eq 200
+      response.status.should eq 422
       response.content.includes?("Schema is invalid").should be_true
     end
   end

--- a/src/marten/cli/templates/auth/templates/spec/handlers/password_reset_initiate_handler_spec.cr.ecr
+++ b/src/marten/cli/templates/auth/templates/spec/handlers/password_reset_initiate_handler_spec.cr.ecr
@@ -28,7 +28,7 @@ describe <%= context.module_name %>::PasswordResetInitiateHandler do
       url = Marten.routes.reverse("<%= context.label %>:password_reset_initiate")
       response = Marten::Spec.client.post(url, data: {"email": ""})
 
-      response.status.should eq 200
+      response.status.should eq 422
       response.content.includes?("Reset password").should be_true
     end
 

--- a/src/marten/cli/templates/auth/templates/spec/handlers/password_update_handler_spec.cr.ecr
+++ b/src/marten/cli/templates/auth/templates/spec/handlers/password_update_handler_spec.cr.ecr
@@ -72,7 +72,7 @@ describe <%= context.module_name %>::PasswordUpdateHandler do
         "new_confirm_password": "",
       })
 
-      response.status.should eq 200
+      response.status.should eq 422
       response.content.includes?("Update password").should be_true
     end
   end

--- a/src/marten/cli/templates/auth/templates/spec/handlers/sign_in_handler_spec.cr.ecr
+++ b/src/marten/cli/templates/auth/templates/spec/handlers/sign_in_handler_spec.cr.ecr
@@ -28,7 +28,7 @@ describe <%= context.module_name %>::SignInHandler do
       url = Marten.routes.reverse("<%= context.label %>:sign_in")
       response = Marten::Spec.client.post(url, data: {"email": "", "password": ""})
 
-      response.status.should eq 200
+      response.status.should eq 422
       response.content.includes?("Sign in").should be_true
       Marten::Spec.client.get(Marten.routes.reverse("<%= context.label %>:profile")).status.should eq 302
     end
@@ -39,7 +39,7 @@ describe <%= context.module_name %>::SignInHandler do
       url = Marten.routes.reverse("<%= context.label %>:sign_in")
       response = Marten::Spec.client.post(url, data: {"email": user.email, "password": "bad"})
 
-      response.status.should eq 200
+      response.status.should eq 422
       response.content.includes?("Sign in").should be_true
       response.content.includes?(
         "Please enter a correct email address and password. Note that both fields may be case-sensitive."
@@ -53,7 +53,7 @@ describe <%= context.module_name %>::SignInHandler do
       url = Marten.routes.reverse("<%= context.label %>:sign_in")
       response = Marten::Spec.client.post(url, data: {"email": user.email, "password": "bad"})
 
-      response.status.should eq 200
+      response.status.should eq 422
       response.content.includes?("Sign in").should be_true
       response.content.includes?(
         "Please enter a correct email address and password. Note that both fields may be case-sensitive."

--- a/src/marten/cli/templates/auth/templates/spec/handlers/sign_up_handler_spec.cr.ecr
+++ b/src/marten/cli/templates/auth/templates/spec/handlers/sign_up_handler_spec.cr.ecr
@@ -28,7 +28,7 @@ describe <%= context.module_name %>::SignUpHandler do
       url = Marten.routes.reverse("<%= context.label %>:sign_up")
       response = Marten::Spec.client.post(url, data: {"email": "", "password1": "", "password2": ""})
 
-      response.status.should eq 200
+      response.status.should eq 422
       response.content.includes?("Sign up").should be_true
     end
 

--- a/src/marten/handlers/schema.cr
+++ b/src/marten/handlers/schema.cr
@@ -105,7 +105,7 @@ module Marten
       #
       # By default, this will render the configured template and return a corresponding HTTP response.
       def process_invalid_schema
-        render_to_response(context)
+        render(template_name, context: context, status: 422)
       end
 
       # Produces the response when the processed schema is valid.


### PR DESCRIPTION
Proof of concept for #167.
I tested it locally and everything works. It also fixes [Turbo](https://turbo.hotwired.dev) content update.
The only breaking case is that if some front-end JS code relies on the response status, which is unlikely as it's not an API call, but HTML rendering.