### PR TITLE
Add `--fingerprint` option to `collectassets`

### DIFF
--- a/docs/docs/assets/introduction.md
+++ b/docs/docs/assets/introduction.md
@@ -93,6 +93,12 @@ Considering the above manifest example, trying to resolve `app/home.css` would p
 Marten.assets.url("app/home.css") # => "/assets/app/home.9495841be78cdf06c45d.css"
 ```
 
+:::info
+Additionally, the collectassets command provides a `--fingerprint` option. Using this option automatically fingerprints the collected assets and generates a `manifest.json` file, which maps the original file paths to their fingerprinted versions.
+
+When the `--fingerprint` option is used, it's important to include the path to the generated "manifest.json" in the appropriate environment.config file, otherwise the collected assets can't be found when the URL is resolved.
+:::
+
 ## Resolving asset URLs
 
 As mentioned previously, assets are collected and persisted in a specific storage. When building HTML [templates](../templates/introduction.md), you will usually need to "resolve" the URL of assets to generate the absolute URLs that should be inserted into stylesheet or script tags (for example).

--- a/docs/docs/development/reference/management-commands.md
+++ b/docs/docs/development/reference/management-commands.md
@@ -36,6 +36,8 @@ Please refer to [Asset handling](../../assets/introduction.md) to learn more abo
 ### Options
 
 * `--no-input` - Does not show prompts to the user
+* `--fingerprint` - Attaches a fingerprint to the collected assets
+* `--manifest-path` - Configures where the manifest.json is stored. Only relevant if `--fingerprint` is activated.
 
 ### Examples
 

--- a/spec/marten/cli/manage/command/collect_assets_spec.cr
+++ b/spec/marten/cli/manage/command/collect_assets_spec.cr
@@ -116,9 +116,10 @@ describe Marten::CLI::Manage::Command::CollectAssets do
       stdout = IO::Memory.new
 
       original_css_asset_path = "spec/test_project/assets/css/test.css"
+      manifest_path = File.expand_path "spec/src/manifest.json"
 
       command = Marten::CLI::Manage::Command::CollectAssets.new(
-        options: ["--no-color", "--no-input", "--fingerprint"],
+        options: ["--no-color", "--no-input", "--fingerprint", "--manifest-path", manifest_path],
         stdin: stdin,
         stdout: stdout
       )
@@ -130,13 +131,13 @@ describe Marten::CLI::Manage::Command::CollectAssets do
       command.handle
 
       output = stdout.rewind.gets_to_end
-      output.includes?("Copying css/test.#{file_digest}.css...").should be_true
-      output.includes?("Creating manifest.json...").should be_true
+      output.includes?("Copying css/test.css (#{file_digest})...").should be_true
+      output.includes?("Creating #{manifest_path}...").should be_true
 
       File.exists?("spec/assets/css/test.#{file_digest}.css").should be_true
-      File.exists?("spec/assets/manifest.json").should be_true
+      File.exists?("spec/src/manifest.json").should be_true
 
-      json = File.open("spec/assets/manifest.json") do |file|
+      json = File.open("spec/src/manifest.json") do |file|
         JSON.parse(file)
       end
 

--- a/src/marten/cli/manage/command/collect_assets.cr
+++ b/src/marten/cli/manage/command/collect_assets.cr
@@ -1,3 +1,5 @@
+require "digest/sha256"
+
 module Marten
   module CLI
     class Manage
@@ -6,9 +8,12 @@ module Marten
           command_name :collectassets
           help "Collect all the assets and copy them in a unique storage."
 
+          @fingerprint : Bool = false
+          @fingerprint_mapping = Hash(String, String).new
           @no_input : Bool = false
 
           def setup
+            on_option("fingerprint", "Add a fingerprint to the collected assets") { @fingerprint = true }
             on_option("no-input", "Do not show prompts to the user") { @no_input = true }
           end
 
@@ -29,6 +34,21 @@ module Marten
             collect
           end
 
+          private def calculate_fingerprint(relative_path, io)
+            last_dot_index = relative_path.rindex(".")
+            old_path = relative_path
+
+            if last_dot_index != -1
+              sha = Digest::SHA256.new
+              sha.update io
+              io.rewind
+              relative_path = relative_path[0...last_dot_index] + ".#{sha.hexfinal}" + relative_path[last_dot_index..]
+              @fingerprint_mapping[old_path] = relative_path
+            end
+
+            relative_path
+          end
+
           private def collect
             collected_count = 0
 
@@ -42,14 +62,31 @@ module Marten
             if collected_count == 0
               print("No assets to collect...")
             end
+
+            if fingerprint? && collected_count > 0
+              manifest_file_name = "manifest.json"
+
+              print("  › Creating #{style(manifest_file_name, mode: :dim)}...", ending: "")
+
+              io = IO::Memory.new(@fingerprint_mapping.to_json.to_s)
+              Marten.assets.storage.write(manifest_file_name, io)
+
+              print(style(" DONE", fore: :light_green, mode: :bold))
+            end
           end
 
           private def copy_asset_file(relative_path, absolute_path)
             File.open(absolute_path) do |io|
+              relative_path = calculate_fingerprint(relative_path, io) if fingerprint?
+
               print("  › Copying #{style(relative_path, mode: :dim)}...", ending: "")
-              Marten.assets.storage.write(relative_path, io)
+              Marten.assets.storage.write(relative_path.not_nil!, io)
               print(style(" DONE", fore: :light_green, mode: :bold))
             end
+          end
+
+          private def fingerprint?
+            @fingerprint
           end
 
           private def no_input?


### PR DESCRIPTION
This commit adds a `--fingerprint` option, which automatically adds a fingerprint to the collected assets. In addition a `manifest.json` is created, which maps the original file paths to the fingerprinted paths. 

The `manifest.json` is stored in `src/manifest.json` by default. The new `--manifest-path' option allows you to specify an alternate path where the `manifest.json' should be stored if required.

Closes #205 