### PR TITLE
Assets max age

### DIFF
--- a/docs/docs/assets/introduction.md
+++ b/docs/docs/assets/introduction.md
@@ -119,6 +119,12 @@ It is also possible to resolve asset URLs programmatically in Crystal. To do so,
 Marten.assets.url("app/app.css") # => "/assets/app/app.css"
 ```
 
+## Cache Control
+
+```crystal
+config.assets.max_age = 7200
+```
+
 ## Serving assets in development
 
 Marten provides a handler that you can use to serve assets in development environments only. This handler ([`Marten::Handlers::Defaults::Development::ServeAsset`](pathname:///api/dev/Marten/Handlers/Defaults/Development/ServeAsset.html)) is automatically mapped to a route when creating new projects through the use of the [`new`](../development/reference/management-commands.md#new) management command:

--- a/docs/docs/assets/introduction.md
+++ b/docs/docs/assets/introduction.md
@@ -119,12 +119,6 @@ It is also possible to resolve asset URLs programmatically in Crystal. To do so,
 Marten.assets.url("app/app.css") # => "/assets/app/app.css"
 ```
 
-## Cache Control
-
-```crystal
-config.assets.max_age = 7200
-```
-
 ## Serving assets in development
 
 Marten provides a handler that you can use to serve assets in development environments only. This handler ([`Marten::Handlers::Defaults::Development::ServeAsset`](pathname:///api/dev/Marten/Handlers/Defaults/Development/ServeAsset.html)) is automatically mapped to a route when creating new projects through the use of the [`new`](../development/reference/management-commands.md#new) management command:

--- a/spec/marten/conf/global_settings/assets_spec.cr
+++ b/spec/marten/conf/global_settings/assets_spec.cr
@@ -218,4 +218,19 @@ describe Marten::Conf::GlobalSettings::Assets do
       assets_conf.url.should eq "/assets/url/"
     end
   end
+
+  describe "#max_age" do
+    it "returns the expected default value" do
+      assets_conf = Marten::Conf::GlobalSettings::Assets.new
+      assets_conf.max_age.should eq 3600
+    end
+  end
+
+  describe "#max_age=" do
+    it "allows to set max_age value" do
+      assets_conf = Marten::Conf::GlobalSettings::Assets.new
+      assets_conf.max_age = 7200
+      assets_conf.max_age.should eq 7200
+    end
+  end
 end

--- a/spec/marten/conf/global_settings/assets_spec.cr
+++ b/spec/marten/conf/global_settings/assets_spec.cr
@@ -227,7 +227,7 @@ describe Marten::Conf::GlobalSettings::Assets do
   end
 
   describe "#max_age=" do
-    it "allows to set max_age value" do
+    it "allows to set the max_age value" do
       assets_conf = Marten::Conf::GlobalSettings::Assets.new
       assets_conf.max_age = 7200
       assets_conf.max_age.should eq 7200

--- a/spec/marten/middleware/asset_serving_spec.cr
+++ b/spec/marten/middleware/asset_serving_spec.cr
@@ -299,7 +299,6 @@ describe Marten::Middleware::AssetServing do
           ->{ Marten::HTTP::Response.new("Unknown!", content_type: "text/plain", status: 200) }
         )
 
-        uncompressed_content = File.read(File.join(__DIR__, "asset_serving/assets/#{path}"))
         response.headers[:"Cache-Control"].should eq "private, max-age=7200"
       end
     end

--- a/spec/marten/middleware/asset_serving_spec.cr
+++ b/spec/marten/middleware/asset_serving_spec.cr
@@ -280,26 +280,28 @@ describe Marten::Middleware::AssetServing do
         response.headers[:"Cache-Control"].should eq "private, max-age=3600"
       end
     end
-    it "properly sets the custom Cache-Control header" do
-      Marten.settings.assets.max_age = 7200
-      middleware = Marten::Middleware::AssetServing.new
 
-      ["BigApp.js", "css/BigApp.css"].each do |path|
-        response = middleware.call(
-          Marten::HTTP::Request.new(
-            ::HTTP::Request.new(
-              method: "GET",
-              resource: "/assets/#{path}",
-              headers: HTTP::Headers{
-                "Host"            => "example.com",
-                "Accept-Encoding" => "gzip, deflate, br",
-              }
-            )
-          ),
-          ->{ Marten::HTTP::Response.new("Unknown!", content_type: "text/plain", status: 200) }
-        )
+    it "properly sets the custom Cache-Control header based on the assets.max_age setting" do
+      with_overridden_setting("assets.max_age", 7200) do
+        middleware = Marten::Middleware::AssetServing.new
 
-        response.headers[:"Cache-Control"].should eq "private, max-age=7200"
+        ["BigApp.js", "css/BigApp.css"].each do |path|
+          response = middleware.call(
+            Marten::HTTP::Request.new(
+              ::HTTP::Request.new(
+                method: "GET",
+                resource: "/assets/#{path}",
+                headers: HTTP::Headers{
+                  "Host"            => "example.com",
+                  "Accept-Encoding" => "gzip, deflate, br",
+                }
+              )
+            ),
+            ->{ Marten::HTTP::Response.new("Unknown!", content_type: "text/plain", status: 200) }
+          )
+
+          response.headers[:"Cache-Control"].should eq "private, max-age=7200"
+        end
       end
     end
   end

--- a/spec/marten/middleware/asset_serving_spec.cr
+++ b/spec/marten/middleware/asset_serving_spec.cr
@@ -281,7 +281,7 @@ describe Marten::Middleware::AssetServing do
       end
     end
 
-    it "properly sets the custom Cache-Control header based on the assets.max_age setting" do
+    it "properly sets the custom Cache-Control header based on the assets.max_age setting value" do
       with_overridden_setting("assets.max_age", 7200) do
         middleware = Marten::Middleware::AssetServing.new
 

--- a/src/marten/conf/global_settings/assets.cr
+++ b/src/marten/conf/global_settings/assets.cr
@@ -9,6 +9,7 @@ module Marten
         @root : String = "assets"
         @storage : Core::Storage::Base? = nil
         @url : String = "/assets/"
+        @max_age : Int64 = 3600
 
         # Returns a boolean indicating whether assets should be looked for inside installed applications.
         getter app_dirs
@@ -35,6 +36,12 @@ module Marten
 
         # Allows to set the base URL to use when exposing asset URLs.
         setter url
+
+        # Allows to set the Cache-Control max-age.
+        setter max_age
+
+        # Returns the Cache-Control max-age value
+        getter max_age
 
         # Allows to set the directories where assets should be looked for.
         def dirs=(dirs : Array(Path | String | Symbol))

--- a/src/marten/middleware/asset_serving.cr
+++ b/src/marten/middleware/asset_serving.cr
@@ -9,7 +9,7 @@ module Marten
     #
     # It should also be noted that this middleware will automatically compress served assets using GZip or deflate based
     # on the incoming Accept-Encoding header. The middleware also sets the Cache-Control header and specifies a max-age
-    # of 3600s.
+    # of 3600s as default and can be configured in `config.assets.max_age` settings.
     class AssetServing < Middleware
       def call(request : Marten::HTTP::Request, get_response : Proc(Marten::HTTP::Response)) : Marten::HTTP::Response
         return get_response.call if !request.path.starts_with?(Marten.settings.assets.url)
@@ -89,7 +89,7 @@ module Marten
         response.headers[:"Content-Length"] = response.content.bytesize
         response.headers[:"ETag"] = %{W/"#{File.info(asset_file_path).modification_time.to_unix}"}
         response.headers[:"Content-Encoding"] = content_encoding if !content_encoding.nil?
-        response.headers[:"Cache-Control"] = "private, max-age=3600"
+        response.headers[:"Cache-Control"] = "private, max-age=#{Marten.settings.assets.max_age}"
 
         response
       end

--- a/src/marten/middleware/asset_serving.cr
+++ b/src/marten/middleware/asset_serving.cr
@@ -9,7 +9,7 @@ module Marten
     #
     # It should also be noted that this middleware will automatically compress served assets using GZip or deflate based
     # on the incoming Accept-Encoding header. The middleware also sets the Cache-Control header and specifies a max-age
-    # of 3600s as default and can be configured in `config.assets.max_age` settings.
+    # of 3600s as default and can be configured in the `config.assets.max_age` setting.
     class AssetServing < Middleware
       def call(request : Marten::HTTP::Request, get_response : Proc(Marten::HTTP::Response)) : Marten::HTTP::Response
         return get_response.call if !request.path.starts_with?(Marten.settings.assets.url)


### PR DESCRIPTION
Allow changing the `max-age` value in the settings. It still retain the default `3600s` if `max_age` is not configured.

https://github.com/martenframework/marten/issues/221