### PR TITLE
content_type class method to generic handlers

### DIFF
--- a/spec/marten/handlers/concerns/rendering_spec.cr
+++ b/spec/marten/handlers/concerns/rendering_spec.cr
@@ -246,6 +246,34 @@ describe Marten::Handlers::Rendering do
       end
     end
   end
+
+  describe "#content_type" do
+    it "returns the default content_type if not configured" do
+      request = Marten::HTTP::Request.new(
+        ::HTTP::Request.new(
+          method: "GET",
+          resource: "",
+          headers: HTTP::Headers{"Host" => "example.com"}
+        )
+      )
+      handler = Marten::Handlers::RenderingSpec::TestHandlerWithDefaultContentType.new(request)
+
+      handler.content_type.should eq "text/html"
+    end
+
+    it "returns the custom content_type if configured" do
+      request = Marten::HTTP::Request.new(
+        ::HTTP::Request.new(
+          method: "GET",
+          resource: "",
+          headers: HTTP::Headers{"Host" => "example.com"}
+        )
+      )
+      handler = Marten::Handlers::RenderingSpec::TestHandlerWithCustomContentType.new(request)
+
+      handler.content_type.should eq "text/plain"
+    end
+  end
 end
 
 module Marten::Handlers::RenderingSpec
@@ -308,5 +336,17 @@ module Marten::Handlers::RenderingSpec
 
   class TestHandlerWithoutTemplate < Marten::Handler
     include Marten::Handlers::Rendering
+  end
+
+  class TestHandlerWithDefaultContentType < Marten::Handler
+    include Marten::Handlers::Rendering
+    template_name "specs/handlers/concerns/rendering/handler.html"
+  end
+
+  class TestHandlerWithCustomContentType < Marten::Handler
+    include Marten::Handlers::Rendering
+
+    template_name "specs/handlers/concerns/rendering/handler.html"
+    content_type "text/plain"
   end
 end

--- a/spec/marten/handlers/template_spec.cr
+++ b/spec/marten/handlers/template_spec.cr
@@ -19,6 +19,25 @@ describe Marten::Handlers::Template do
       response.content.strip.should eq "Hello World, John Doe!"
     end
   end
+
+  describe "with content_type" do
+    it "returns a HTTP response with configured content_type" do
+      request = Marten::HTTP::Request.new(
+        ::HTTP::Request.new(
+          method: "GET",
+          resource: "",
+          headers: HTTP::Headers{"Host" => "example.com"}
+        )
+      )
+
+      handler = Marten::Handlers::TemplateSpec::TestHandlerWithContentType.new(request)
+      response = handler.get
+
+      response.status.should eq 200
+      response.content_type.should eq "text/plain"
+      response.content.strip.should eq "Hello World, John Doe!"
+    end
+  end
 end
 
 module Marten::Handlers::TemplateSpec
@@ -33,5 +52,16 @@ module Marten::Handlers::TemplateSpec
   end
 
   class TestHandlerWithoutContext < Marten::Handlers::Template
+  end
+
+  class TestHandlerWithContentType < Marten::Handlers::Template
+    template_name "specs/handlers/template/test.html"
+    content_type "text/plain"
+
+    before_render :add_name_to_context
+
+    private def add_name_to_context
+      context[:name] = "John Doe"
+    end
   end
 end

--- a/src/marten/handlers/concerns/rendering.cr
+++ b/src/marten/handlers/concerns/rendering.cr
@@ -6,6 +6,9 @@ module Marten
         # Returns the configured template name.
         class_getter template_name : String?
 
+        # Returns the configured content type.
+        class_getter content_type : String?
+
         extend Marten::Handlers::Rendering::ClassMethods
       end
 
@@ -14,6 +17,11 @@ module Marten
         def template_name(template_name : String?)
           @@template_name = template_name
         end
+
+        # Allows to configure the content type of the response
+        def content_type(content_type : String)
+          @@content_type = content_type
+        end
       end
 
       # Renders the configured template for a specific `context` object and produces an HTTP response.
@@ -21,7 +29,7 @@ module Marten
         context : Hash | NamedTuple | Nil | Marten::Template::Context = nil,
         status : ::HTTP::Status | Int32 = 200
       )
-        render(template_name, context: context, status: status)
+        render(template_name, context: context, status: status, content_type: content_type)
       end
 
       # Returns the template name that should be rendered by the handler.
@@ -30,6 +38,10 @@ module Marten
           "'#{self.class.name}' must define a template name via the '::template_name' class method method or by " \
           "overriding the '#template_name' method"
         )
+      end
+
+      def content_type : String
+        self.class.content_type || Marten::HTTP::Response::DEFAULT_CONTENT_TYPE
       end
     end
   end


### PR DESCRIPTION
Added `content_type` class method to the `Rendering` concern which can be used to specify a custom content type for generic handlers.

https://github.com/martenframework/marten/issues/145