### PR TITLE
csrf-input tag that uses csrf_token as value

### DIFF
--- a/spec/marten/template/tag/csrf_input_spec.cr
+++ b/spec/marten/template/tag/csrf_input_spec.cr
@@ -1,0 +1,49 @@
+require "./spec_helper"
+
+describe Marten::Template::Tag::CsrfInput do
+  describe "::new" do
+    it "raises if the csrf_input tag contains an argument" do
+      parser = Marten::Template::Parser.new("")
+
+      expect_raises(
+        Marten::Template::Errors::InvalidSyntax,
+        "Malformed csrf_input tag: takes no argument"
+      ) do
+        Marten::Template::Tag::CsrfInput.new(parser, %(csrf_input "arg"))
+      end
+    end
+  end
+
+  describe "#render" do
+    it "renders a html hidden input tag with csrftoken as name and handler's csrf_token as value" do
+      parser = Marten::Template::Parser.new("")
+
+      tag = Marten::Template::Tag::CsrfInput.new(parser, "csrf_input")
+      tag.should be_a Marten::Template::Tag::CsrfInput
+
+      handler = Marten::Template::Tag::CsrfInputSpec::TestHandler.new(
+        Marten::HTTP::Request.new(
+          ::HTTP::Request.new(
+            method: "GET",
+            resource: "/test/xyz",
+            headers: HTTP::Headers{"Host" => "example.com"}
+          )
+        )
+      )
+      handler.process_dispatch
+
+      context = Marten::Template::Context.new
+      context["handler"] = handler
+
+      tag.render(context).includes?(%(<input type="hidden" name="csrftoken" value="#{handler.get_csrf_token}" />))
+    end
+  end
+end
+
+module Marten::Template::Tag::CsrfInputSpec
+  class TestHandler < Marten::Handler
+    def get
+      respond "OK"
+    end
+  end
+end

--- a/spec/marten/template/tag_spec.cr
+++ b/spec/marten/template/tag_spec.cr
@@ -3,13 +3,14 @@ require "./spec_helper"
 describe Marten::Template::Tag do
   describe "::get" do
     it "returns the right built-in tag classes for the expected tag names" do
-      Marten::Template::Tag.registry.size.should eq 20
+      Marten::Template::Tag.registry.size.should eq 21
       Marten::Template::Tag.get("asset").should eq Marten::Template::Tag::Asset
       Marten::Template::Tag.get("assign").should eq Marten::Template::Tag::Assign
       Marten::Template::Tag.get("block").should eq Marten::Template::Tag::Block
       Marten::Template::Tag.get("cache").should eq Marten::Template::Tag::Cache
       Marten::Template::Tag.get("capture").should eq Marten::Template::Tag::Capture
       Marten::Template::Tag.get("csrf_token").should eq Marten::Template::Tag::CsrfToken
+      Marten::Template::Tag.get("csrf_input").should eq Marten::Template::Tag::CsrfInput
       Marten::Template::Tag.get("extend").should eq Marten::Template::Tag::Extend
       Marten::Template::Tag.get("for").should eq Marten::Template::Tag::For
       Marten::Template::Tag.get("if").should eq Marten::Template::Tag::If

--- a/src/marten/template/tag.cr
+++ b/src/marten/template/tag.cr
@@ -30,6 +30,7 @@ module Marten
       register "cache", Cache
       register "capture", Capture
       register "csrf_token", CsrfToken
+      register "csrf_input", CsrfInput
       register "extend", Extend
       register "for", For
       register "if", If

--- a/src/marten/template/tag/csrf_input.cr
+++ b/src/marten/template/tag/csrf_input.cr
@@ -1,0 +1,36 @@
+require "./concerns/*"
+
+module Marten
+  module Template
+    module Tag
+      # The `csrf_input` template tag.
+      #
+      # The `csrf_input` tag generates a hidden html input tag with `csrftoken` as name and
+      # the output of `csrf_token` tag as value.
+      #
+      # ```html
+      # <input type="hidden" name="csrftoken" value="randomStrinGgenEratedbyCSRFtoken" />
+      # ```
+      class CsrfInput < Base
+        include CanSplitSmartly
+
+        @assigned_to : String? = nil
+
+        def initialize(_parser : Parser, source : String)
+          parts = split_smartly(source)
+
+          if parts.size != 1
+            raise Errors::InvalidSyntax.new("Malformed csrf_input tag: takes no argument")
+          end
+        end
+
+        def render(context : Context) : String
+          handler = context["handler"]?.try(&.raw).as?(Handlers::Base)
+          return "" if handler.nil?
+
+          %(<input type="hidden" name="csrftoken" value="#{handler.get_csrf_token}" />)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Added a new `csrf_input` tag that would take the output of the `csrf_token` tag and create the html hidden input that uses that output as value.

https://github.com/martenframework/marten/issues/200