### PR TITLE
default development log level `Log::Severity::Debug`

### DIFF
--- a/docs/docs/development/reference/settings.md
+++ b/docs/docs/development/reference/settings.md
@@ -66,6 +66,8 @@ Default: `Log::Severity::Info`
 
 The default log level used by the application. Any severity defined in the [`Log::Severity`](https://crystal-lang.org/api/Log/Severity.html) enum can be used.
 
+The [development environment](../settings#environments) in new Marten projects is configured with the more verbose `Log::Severity::Debug` log level, as it provides valuable debugging information during development of the project.
+
 ### `middleware`
 
 Default: `[] of Marten::Middleware.class`

--- a/src/marten/cli/manage/command/new/templates/project/config/settings/development.cr.ecr
+++ b/src/marten/cli/manage/command/new/templates/project/config/settings/development.cr.ecr
@@ -6,4 +6,8 @@ Marten.configure :development do |config|
   # Print sent emails to the standard output in development.
   # https://martenframework.com/docs/development/reference/settings#emailing-settings
   config.emailing.backend = Marten::Emailing::Backend::Development.new(print_emails: true)
+
+  # More verbose log level in development.
+  # https://martenframework.com/docs/development/reference/settings#log_level
+  config.log_level = Log::Severity::Debug
 end


### PR DESCRIPTION
Set log level to `Log::Severity::Debug` in `config/settings/development.cr` when a new project is created and mention this in the documentation.

fixes https://github.com/martenframework/marten/issues/239