### PR TITLE
Extract Marten::Server handlers into separate method

### DIFF
--- a/src/marten/server.cr
+++ b/src/marten/server.cr
@@ -8,15 +8,17 @@ module Marten
 
     # Returns the global HTTP server instance.
     def self.instance : ::HTTP::Server
-      @@instance ||= ::HTTP::Server.new(
-        [
-          ::HTTP::ErrorHandler.new,
-          Handlers::Logger.new,
-          Handlers::Error.new,
-          Handlers::Middleware.new,
-          Handlers::Routing.new,
-        ]
-      )
+      @@instance ||= ::HTTP::Server.new(handlers)
+    end
+
+    def self.handlers
+      [
+        ::HTTP::ErrorHandler.new,
+        Handlers::Logger.new,
+        Handlers::Error.new,
+        Handlers::Middleware.new,
+        Handlers::Routing.new,
+      ]
     end
 
     # Setups the server (TCP binding).


### PR DESCRIPTION
### Summary

This PR refactors the HTTP server initialization in Marten to facilitate its use in a serverless environment. By separating the server instance creation and the handler configuration, users can now easily access the handlers independently of the server instance.

### Changes

- **Refactored `self.instance` method**: 
  - Moved handler configuration to a separate `self.handlers` method.
  - `self.instance` now calls `self.handlers` for handler configuration.
  
  ```crystal
  def self.instance : ::HTTP::Server
    @@instance ||= ::HTTP::Server.new(handlers)
  end
  
  def self.handlers
    [
      ::HTTP::ErrorHandler.new,
      Handlers::Logger.new,
      Handlers::Error.new,
      Handlers::Middleware.new,
      Handlers::Routing.new,
    ]
  end
  ```

### Motivation

The primary motivation for this change is to support hosting Marten in a serverless environment. In such environments, only the handlers are required, not a full HTTP server instance. This refactoring allows for more flexible usage scenarios, including serverless setups.

### Testing

This change is experimental and does not include comprehensive tests or examples. If there are specific use cases or scenarios that need to be covered, please let me know, and I will be happy to add them.

### Additional Notes

- If there are any additional changes or adjustments needed to fully support serverless environments, please provide feedback.
- This is an initial step towards enabling serverless capabilities, and further refinements may be necessary as we gather more insights and use cases.

---

Thank you for considering this PR. I look forward to your feedback and any suggestions to improve this implementation.

---