### PR TITLE
Added expires property to the session

### DIFF
--- a/spec/marten/spec/client_spec.cr
+++ b/spec/marten/spec/client_spec.cr
@@ -368,6 +368,30 @@ describe Marten::Spec::Client do
       client.session.should be_a Marten::HTTP::Session::Store::Base
       client.cookies[Marten.settings.sessions.cookie_name].should eq client.session.session_key
     end
+
+    it "properly set time of the session expire" do
+      client = Marten::Spec::Client.new
+
+      client.session.expires_in = 2.days
+      client.session.expires_in.should eq 2.days
+      (2.days.from_now - client.session.expires_at.not_nil!).should be <= 1.seconds
+      client.session.expires_at = 3.days.from_now
+      (3.days.from_now - client.session.expires_at.not_nil!).should be <= 1.seconds
+    end
+
+    it "returns the default expiration time for the session" do
+      client = Marten::Spec::Client.new
+
+      default_expires_in = Time::Span.new(seconds: Marten.settings.sessions.cookie_max_age)
+      client.session.expires_in.should eq default_expires_in
+    end
+
+    it "returns nil if session expires when closing the browser" do
+      client = Marten::Spec::Client.new
+
+      client.session.expires_at_browser_close = true
+      client.session.expires_at.should be_nil
+    end
   end
 
   describe "#trace" do

--- a/src/marten/http/session/store/base.cr
+++ b/src/marten/http/session/store/base.cr
@@ -38,6 +38,11 @@ module Marten
             @expires_in ||= Time::Span.new(seconds: Marten.settings.sessions.cookie_max_age)
           end
 
+          def expires_at=(value : Time)
+            @modified = true
+            @expires_in = value - Time.local
+          end
+
           def expires_at
             return nil if expires_at_browser_close
             Time.local + expires_in

--- a/src/marten/http/session/store/base.cr
+++ b/src/marten/http/session/store/base.cr
@@ -9,25 +9,38 @@ module Marten
           @accessed : Bool = false
           @modified : Bool = false
           @session_hash : SessionHash? = nil
-          @expires : Int32? = nil
+          @expires_in : Time::Span? = nil
+          @expires_at_browser_close : Bool = false
 
           getter session_key
+
+          getter expires_at_browser_close
 
           def initialize(@session_key : String?)
           end
 
-          def expires=(value : Int32)
-            @expires = value
+          def expires_at_browser_close=(value : Bool)
             @modified = true
+            @expires_at_browser_close = value
           end
 
-          def expires
-            @expires ||= Marten.settings.sessions.cookie_max_age
+          def expires_in=(value : Time::Span)
+            @modified = true
+            @expires_in = value
+          end
+
+          def expires_in=(value : Int64)
+            @modified = true
+            @expires_in = Time::Span.new(seconds: value)
+          end
+
+          def expires_in
+            @expires_in ||= Time::Span.new(seconds: Marten.settings.sessions.cookie_max_age)
           end
 
           def expires_at
-            return nil if expires == 0
-            Time.local + Time::Span.new(seconds: expires)
+            return nil if expires_at_browser_close
+            Time.local + expires_in
           end
 
           # Returns the value associated with the passed key or raises a `KeyError` exception if not found.

--- a/src/marten/http/session/store/base.cr
+++ b/src/marten/http/session/store/base.cr
@@ -9,10 +9,25 @@ module Marten
           @accessed : Bool = false
           @modified : Bool = false
           @session_hash : SessionHash? = nil
+          @expires : Int32? = nil
 
           getter session_key
 
           def initialize(@session_key : String?)
+          end
+
+          def expires=(value : Int32)
+            @expires = value
+            @modified = true
+          end
+
+          def expires
+            @expires ||= Marten.settings.sessions.cookie_max_age
+          end
+
+          def expires_at
+            return nil if expires == 0
+            Time.local + Time::Span.new(seconds: expires)
           end
 
           # Returns the value associated with the passed key or raises a `KeyError` exception if not found.

--- a/src/marten/middleware/session.cr
+++ b/src/marten/middleware/session.cr
@@ -46,7 +46,7 @@ module Marten
         response.cookies.set(
           Marten.settings.sessions.cookie_name,
           request.session.session_key.not_nil!,
-          expires: Time.local + Time::Span.new(seconds: Marten.settings.sessions.cookie_max_age),
+          expires: request.session.expires_at,
           domain: Marten.settings.sessions.cookie_domain,
           secure: Marten.settings.sessions.cookie_secure,
           http_only: Marten.settings.sessions.cookie_http_only,


### PR DESCRIPTION
Now we can set the expiration time for cookies.
```cr
session.expires = {TIME IN SECONDS}
```
Note: _Value 0 is would make the session last as long as the browser is open._