### PR TITLE
Fix context example for template handler

### DIFF
--- a/docs/docs/handlers-and-http/reference/generic-handlers.md
+++ b/docs/docs/handlers-and-http/reference/generic-handlers.md
@@ -306,7 +306,7 @@ If you need to, it is possible to customize the context that is used to render t
 class HomeHandler < Marten::Handlers::Template
   template_name "app/home.html"
 
-  before_render add_recent_articles_to_context
+  before_render :add_recent_articles_to_context
 
   private def add_recent_articles_to_context : Nil
     context[:recent_articles] = Article.all.order("-published_at")[:5]

--- a/docs/versioned_docs/version-0.4/handlers-and-http/reference/generic-handlers.md
+++ b/docs/versioned_docs/version-0.4/handlers-and-http/reference/generic-handlers.md
@@ -219,7 +219,7 @@ If you need to, it is possible to customize the context that is used to render t
 class HomeHandler < Marten::Handlers::Template
   template_name "app/home.html"
 
-  before_render add_recent_articles_to_context
+  before_render :add_recent_articles_to_context
 
   private def add_recent_articles_to_context : Nil
     context[:recent_articles] = Article.all.order("-published_at")[:5]

--- a/docs/versioned_docs/version-0.5/handlers-and-http/reference/generic-handlers.md
+++ b/docs/versioned_docs/version-0.5/handlers-and-http/reference/generic-handlers.md
@@ -306,7 +306,7 @@ If you need to, it is possible to customize the context that is used to render t
 class HomeHandler < Marten::Handlers::Template
   template_name "app/home.html"
 
-  before_render add_recent_articles_to_context
+  before_render :add_recent_articles_to_context
 
   private def add_recent_articles_to_context : Nil
     context[:recent_articles] = Article.all.order("-published_at")[:5]


### PR DESCRIPTION
All current docs that are showing an example of how to add a context variable via the `before_render` macro were missing a colon before the function specifier