### PR TITLE
Bugifx: Fix display of nested routes

### DIFF
--- a/src/marten/cli/manage/command/routes.cr
+++ b/src/marten/cli/manage/command/routes.cr
@@ -15,7 +15,9 @@ module Marten
               when Marten::Routing::Rule::Path
                 print_path(rule, parent_path, parent_name)
               when Marten::Routing::Rule::Map
-                process_routes_map(rule.map, parent_path: rule.path, parent_name: rule.name)
+                rule_name = parent_name ? "#{parent_name}:#{rule.name}" : rule.name
+                rule_path = parent_path + rule.path
+                process_routes_map(rule.map, parent_path: rule_path, parent_name: rule_name)
               end
             end
           end


### PR DESCRIPTION
Fixes the name display of nested routes when using `marten routes`. 

```crystal
# config/routes.cr
Marten.routes.draw do
  path "/admin", Admin::ROUTES, name: "admin"
  # ...
end

# src/apps/admin/routes.cr
module Admin
  ARTICLE_ROUTES = Marten::Routing::Map.draw do
    path "/", Admin::ArticleListHandler, name: "list"
    path "/create", Admin::ArticleCreateHandler, name: "create"
    path "/<pk:int>", Admin::ArticleDetailHandler, name: "detail"
  end
  ROUTES = Marten::Routing::Map.draw do
    path "/articles", ARTICLE_ROUTES, name: "article"
  end
end
```

Would produce

```
/articles/ [article:list] › Admin::ArticleListHandler
/articles/create [article:create] › Admin::ArticleCreateHandler
/articles/<pk:int> [article:detail] › Admin::ArticleDetailHandler
```


instead of

```
/admin/articles/ [admin:article:list] › Admin::ArticleListHandler
/admin/articles/create [admin:article:create] › Admin::ArticleCreateHandler
/admin/articles/<pk:int> [admin:article:detail] › Admin::ArticleDetailHandler
```
