### PR TITLE
Avoid Unnecessary Database Query on Back Relations

### DIFF
--- a/spec/marten/db/query/related_set_spec.cr
+++ b/spec/marten/db/query/related_set_spec.cr
@@ -99,4 +99,15 @@ describe Marten::DB::Query::RelatedSet do
       new_post.author.should eq user
     end
   end
+
+  describe "#fetch" do
+    it "sets the related object automatically" do
+      user = TestUser.create!(username: "jd1", email: "jd1@example.com", first_name: "John", last_name: "Doe")
+      Post.create!(author: user, title: "Post 1")
+
+      qset = Marten::DB::Query::RelatedSet(Post).new(user, "author_id")
+
+      qset[0].get_related_object_variable(:author).should eq user
+    end
+  end
 end

--- a/src/marten/db/query/related_set.cr
+++ b/src/marten/db/query/related_set.cr
@@ -15,6 +15,11 @@ module Marten
                    end
         end
 
+        protected def fetch
+          super
+          @result_cache.not_nil!.each { |r| r.assign_related_object(@instance, @related_field_id) }
+        end
+
         protected def build_record(**kwargs)
           record = M.new(**kwargs)
           record.assign_related_object(@instance, @related_field_id)


### PR DESCRIPTION
With this update, child objects will now reference the already-fetched parent, avoiding redundant queries and improving performance.


Closes #265 