### PR TITLE
Avoid Unnecessary Database Query on Back Relations

### DIFF
--- a/spec/marten/db/field/many_to_one_spec.cr
+++ b/spec/marten/db/field/many_to_one_spec.cr
@@ -212,5 +212,16 @@ describe Marten::DB::Field::ManyToOne do
 
       comment.article_id.should eq article.id!.hexstring
     end
+
+    it "retrieves the related article object for each comment" do
+      article = Marten::DB::Field::ManyToOneSpec::Article.create!(title: "This is an article", body: "This is a test")
+
+      Marten::DB::Field::ManyToOneSpec::Comment.create!(article: article, text: "This article is dope")
+      Marten::DB::Field::ManyToOneSpec::Comment.create!(article: article, text: "This article is not dope")
+
+      comments = Marten::DB::Field::ManyToOneSpec::Comment.all
+
+      comments[0].get_related_object_variable(:article)
+    end
   end
 end

--- a/spec/marten/db/field/one_to_one_spec.cr
+++ b/spec/marten/db/field/one_to_one_spec.cr
@@ -280,5 +280,23 @@ describe Marten::DB::Field::OneToOne do
 
       comment.article_id.should eq article.id!.hexstring
     end
+
+    it "works as expected when target models don't involve interger pk fields" do
+      article = Marten::DB::Field::OneToOneSpec::Article.create!(title: "This is an article", body: "This is a test")
+      Marten::DB::Field::OneToOneSpec::Comment.create!(article: article, text: "This article is dope")
+
+      article = Marten::DB::Field::OneToOneSpec::Article.get(id: article.id).not_nil!
+
+      article.comment!.get_related_object_variable(:article).should_not be_nil
+    end
+
+    it "retrieves the related article object for the comment in a one-to-one association" do
+      article = Marten::DB::Field::OneToOneSpec::Article.create!(title: "This is an article", body: "This is a test")
+      Marten::DB::Field::OneToOneSpec::Comment.create!(article: article, text: "This article is dope")
+
+      article = Marten::DB::Field::OneToOneSpec::Article.get!(id: article.id)
+
+      article.comment!.get_related_object_variable(:article).should_not be_nil
+    end
   end
 end

--- a/spec/marten/db/field/one_to_one_spec.cr
+++ b/spec/marten/db/field/one_to_one_spec.cr
@@ -281,16 +281,16 @@ describe Marten::DB::Field::OneToOne do
       comment.article_id.should eq article.id!.hexstring
     end
 
-    it "works as expected when target models don't involve interger pk fields" do
+    it "retrieves the related article object for the comment in a one-to-one association without bang operator" do
       article = Marten::DB::Field::OneToOneSpec::Article.create!(title: "This is an article", body: "This is a test")
       Marten::DB::Field::OneToOneSpec::Comment.create!(article: article, text: "This article is dope")
 
       article = Marten::DB::Field::OneToOneSpec::Article.get(id: article.id).not_nil!
 
-      article.comment!.get_related_object_variable(:article).should_not be_nil
+      article.comment.not_nil!.get_related_object_variable(:article).should_not be_nil
     end
 
-    it "retrieves the related article object for the comment in a one-to-one association" do
+    it "retrieves the related article object for the comment in a one-to-one association with bang operator!" do
       article = Marten::DB::Field::OneToOneSpec::Article.create!(title: "This is an article", body: "This is a test")
       Marten::DB::Field::OneToOneSpec::Comment.create!(article: article, text: "This article is dope")
 

--- a/spec/marten/db/field/one_to_one_spec/models/comment.cr
+++ b/spec/marten/db/field/one_to_one_spec/models/comment.cr
@@ -1,7 +1,7 @@
 module Marten::DB::Field::OneToOneSpec
   class Comment < Marten::Model
     field :id, :uuid, primary_key: true
-    field :article, :one_to_one, to: Marten::DB::Field::OneToOneSpec::Article
+    field :article, :one_to_one, to: Marten::DB::Field::OneToOneSpec::Article, related: :comment
     field :text, :text
 
     after_initialize :initialize_id

--- a/spec/marten/db/query/related_set_spec.cr
+++ b/spec/marten/db/query/related_set_spec.cr
@@ -99,4 +99,15 @@ describe Marten::DB::Query::RelatedSet do
       new_post.author.should eq user
     end
   end
+
+  describe "#fetch" do
+    it "sets the related object automatically" do
+      user = TestUser.create!(username: "jd1", email: "jd1@example.com", first_name: "John", last_name: "Doe")
+      Post.create!(author: user, title: "Post 1")
+
+      qset = Marten::DB::Query::RelatedSet(Post).new(user, "author_id")
+
+      qset[0].get_related_object_variable(:author).should eq user
+    end
+  end
 end

--- a/spec/marten/db/query/related_set_spec.cr
+++ b/spec/marten/db/query/related_set_spec.cr
@@ -101,13 +101,31 @@ describe Marten::DB::Query::RelatedSet do
   end
 
   describe "#fetch" do
-    it "sets the related object automatically" do
+    it "assigns the related object if assign_related is explicitly set to true" do
+      user = TestUser.create!(username: "jd1", email: "jd1@example.com", first_name: "John", last_name: "Doe")
+      Post.create!(author: user, title: "Post 1")
+
+      qset = Marten::DB::Query::RelatedSet(Post).new(user, "author_id", assign_related: true)
+
+      qset[0].get_related_object_variable(:author).should eq user
+    end
+
+    it "does not assign the related object when assign_related is explicitly set to false" do
+      user = TestUser.create!(username: "jd1", email: "jd1@example.com", first_name: "John", last_name: "Doe")
+      Post.create!(author: user, title: "Post 1")
+
+      qset = Marten::DB::Query::RelatedSet(Post).new(user, "author_id", assign_related: false)
+
+      qset[0].get_related_object_variable(:author).should be_nil
+    end
+
+    it "does not assign the related object when assign_related is left as the default value (false)" do
       user = TestUser.create!(username: "jd1", email: "jd1@example.com", first_name: "John", last_name: "Doe")
       Post.create!(author: user, title: "Post 1")
 
       qset = Marten::DB::Query::RelatedSet(Post).new(user, "author_id")
 
-      qset[0].get_related_object_variable(:author).should eq user
+      qset[0].get_related_object_variable(:author).should be_nil
     end
   end
 end

--- a/src/marten/db/field/many_to_one.cr
+++ b/src/marten/db/field/many_to_one.cr
@@ -202,7 +202,7 @@ module Marten
 
                     def {{ related_field_name.id }}
                       @_reverse_m2o_{{ related_field_name.id }} ||=
-                        {{ model_klass }}::RelatedQuerySet.new(self, {{ field_id.stringify }})
+                        {{ model_klass }}::RelatedQuerySet.new(self, {{ field_id.stringify }}, assign_related: true)
                     end
                   end
                 end

--- a/src/marten/db/field/one_to_one.cr
+++ b/src/marten/db/field/one_to_one.cr
@@ -211,8 +211,8 @@ module Marten
                     def {{ related_field_name.id }}
                       @_reverse_o2o_{{ related_field_name.id }} ||= {{ model_klass }}.get({{ field_id }}: pk)
 
-                      if @_reverse_o2o_{{ related_field_name.id }}
-                        @_reverse_o2o_{{ related_field_name.id }}.not_nil!.{{ relation_attribute_name }} ||= self
+                      if reverse_o2o = @_reverse_o2o_{{ related_field_name.id }}
+                        reverse_o2o.{{ relation_attribute_name }} ||= self
                       end
 
                       @_reverse_o2o_{{ related_field_name.id }}

--- a/src/marten/db/field/one_to_one.cr
+++ b/src/marten/db/field/one_to_one.cr
@@ -210,10 +210,18 @@ module Marten
 
                     def {{ related_field_name.id }}
                       @_reverse_o2o_{{ related_field_name.id }} ||= {{ model_klass }}.get({{ field_id }}: pk)
+
+                      if @_reverse_o2o_{{ related_field_name.id }}
+                        @_reverse_o2o_{{ related_field_name.id }}.not_nil!.{{ relation_attribute_name }} ||= self
+                      end
+
+                      @_reverse_o2o_{{ related_field_name.id }}
                     end
 
                     def {{ related_field_name.id }}!
                       @_reverse_o2o_{{ related_field_name.id }} ||= {{ model_klass }}.get!({{ field_id }}: pk)
+                      @_reverse_o2o_{{ related_field_name.id }}.not_nil!.{{ relation_attribute_name }} ||= self
+                      @_reverse_o2o_{{ related_field_name.id }}.not_nil!
                     end
                   end
                 end

--- a/src/marten/db/model/querying.cr
+++ b/src/marten/db/model/querying.cr
@@ -861,9 +861,10 @@ module Marten
                 def initialize(
                   @instance : Marten::DB::Model,
                   @related_field_id : ::String,
-                  query : Marten::DB::Query::SQL::Query({{ @type }})? = nil
+                  query : Marten::DB::Query::SQL::Query({{ @type }})? = nil,
+                  @assign_related : Bool = false
                 )
-                  super(@instance, @related_field_id, query)
+                  super(@instance, @related_field_id, query, @assign_related)
                 end
 
                 {% for queryset_id, block in MODEL_SCOPES[:custom] %}
@@ -876,7 +877,8 @@ module Marten
                   ::{{ @type }}::RelatedQuerySet.new(
                     instance: @instance,
                     related_field_id: @related_field_id,
-                    query: other_query.nil? ? @query.clone : other_query.not_nil!
+                    query: other_query.nil? ? @query.clone : other_query.not_nil!,
+                    assign_related: @assign_related
                   )
                 end
               end

--- a/src/marten/db/model/querying.cr
+++ b/src/marten/db/model/querying.cr
@@ -862,7 +862,7 @@ module Marten
                   @instance : Marten::DB::Model,
                   @related_field_id : ::String,
                   query : Marten::DB::Query::SQL::Query({{ @type }})? = nil,
-                  @assign_related : Bool = false
+                  @assign_related : ::Bool = false
                 )
                   super(@instance, @related_field_id, query, @assign_related)
                 end

--- a/src/marten/db/query/related_set.cr
+++ b/src/marten/db/query/related_set.cr
@@ -9,7 +9,7 @@ module Marten
           @instance : Marten::DB::Model,
           @related_field_id : String,
           query : SQL::Query(M)? = nil,
-          @assign_related : Bool = false
+          @assign_related : ::Bool = false
         )
           @query = if query.nil?
                      q = SQL::Query(M).new

--- a/src/marten/db/query/related_set.cr
+++ b/src/marten/db/query/related_set.cr
@@ -15,6 +15,11 @@ module Marten
                    end
         end
 
+        protected def fetch
+          super
+          @result_cache.not_nil!.each { |r| r.assign_related_object(@instance, @related_field_id) }
+        end
+
         protected def build_record(**kwargs)
           record = M.new(**kwargs)
           record.assign_related_object(@instance, @related_field_id)


### PR DESCRIPTION
With this update, child objects will now reference the already-fetched parent, avoiding redundant queries and improving performance.

Closes https://github.com/martenframework/marten/issues/265