### PR TITLE
db: add support for custom through models in many-to-many fields

### DIFF
--- a/spec/marten/db/field/many_to_many_spec.cr
+++ b/spec/marten/db/field/many_to_many_spec.cr
@@ -49,6 +49,16 @@ describe Marten::DB::Field::ManyToMany do
     end
   end
 
+  describe "::through" do
+    it "reuse existed class if specified through options" do
+      user = Marten::DB::Field::ManyToManySpec::User.create!(name: "foo")
+      user.roles.should be_empty
+
+      role = Marten::DB::Field::ManyToManySpec::Role.create!(name: "admin")
+      user.roles.add(role)
+    end
+  end
+
   describe "#db_column" do
     it "returns nil" do
       field = Marten::DB::Field::ManyToMany.new(

--- a/spec/marten/db/field/many_to_many_spec/models/role.cr
+++ b/spec/marten/db/field/many_to_many_spec/models/role.cr
@@ -1,0 +1,6 @@
+module Marten::DB::Field::ManyToManySpec
+  class Role < Marten::Model
+    field :id, :big_int, primary_key: true, auto: true
+    field :name, :string, max_size: 255
+  end
+end

--- a/spec/marten/db/field/many_to_many_spec/models/user.cr
+++ b/spec/marten/db/field/many_to_many_spec/models/user.cr
@@ -1,0 +1,9 @@
+module Marten::DB::Field::ManyToManySpec
+  class User < Marten::Model
+    field :id, :big_int, primary_key: true, auto: true
+    field :name, :string, max_size: 255
+    field :roles, :many_to_many,
+      to: Marten::DB::Field::ManyToManySpec::Role,
+      through: Marten::DB::Field::ManyToManySpec::UserRole
+  end
+end

--- a/spec/marten/db/field/many_to_many_spec/models/user_role.cr
+++ b/spec/marten/db/field/many_to_many_spec/models/user_role.cr
@@ -1,0 +1,7 @@
+module Marten::DB::Field::ManyToManySpec
+  class UserRole < Marten::Model
+    field :id, :big_int, primary_key: true, auto: true
+    field :user, :many_to_one, to: Marten::DB::Field::ManyToManySpec::User, related: :user_roles
+    field :role, :many_to_one, to: Marten::DB::Field::ManyToManySpec::Role, related: :user_roles
+  end
+end


### PR DESCRIPTION
This update allows specifying a custom class for the `through` option in many-to-many relationships, providing greater flexibility in defining intermediate models.

Example:

```crystal
class Post < Marten::Model
  # Other fields...

  field :tags, :many_to_many, to: Tag, through: CustomPostTags
end
```

This makes it easier to define and manage custom behavior or attributes within the intermediary model.

Reference: https://github.com/martenframework/marten/issues/13