### PR TITLE
Add custom query for prefetching

### DIFF
--- a/docs/docs/models-and-databases/reference/query-set.md
+++ b/docs/docs/models-and-databases/reference/query-set.md
@@ -262,10 +262,10 @@ query_set = Post.all
 query_set.prefetch(:author__favorite_tags)
 ```
 
-In some situations it might be necessary to use a custom query set for the prefetched records. This is possible by providing a `query_set` argument:
+In some situations, it might be necessary to use a custom query set for the prefetched records. This is possible by using a variant of the `#prefetch` method in which a single relation name and the associated query set (`query_set` argument) are provided:
 
 ```crystal
-# Query all lists and order the list items by its position
+# Query all lists and order the list items by position
 query_set = List.prefetch(:items, query_set: Item.order(:position))
 ```
 

--- a/docs/docs/models-and-databases/reference/query-set.md
+++ b/docs/docs/models-and-databases/reference/query-set.md
@@ -75,7 +75,7 @@ qset_2[2..6]? # returns a "sliced" query set
 
 Combines the current query set with another one using the **AND** operator.
 
-This method returns a new query set that is the result of combining the current query set with another one using the AND SQL operator. 
+This method returns a new query set that is the result of combining the current query set with another one using the AND SQL operator.
 
 For example:
 
@@ -90,7 +90,7 @@ combined_query_set = query_set_1 & query_set_2
 
 Combines the current query set with another one using the **OR** operator.
 
-This method returns a new query set that is the result of combining the current query set with another one using the OR SQL operator. 
+This method returns a new query set that is the result of combining the current query set with another one using the OR SQL operator.
 
 For example:
 
@@ -105,7 +105,7 @@ combined_query_set = query_set_1 | query_set_2
 
 Combines the current query set with another one using the **XOR** operator.
 
-This method returns a new query set that is the result of combining the current query set with another one using the XOR SQL operator. 
+This method returns a new query set that is the result of combining the current query set with another one using the XOR SQL operator.
 
 For example:
 
@@ -260,6 +260,13 @@ It should be noted that it is also possible to follow relations and reverse rela
 ```crystal
 query_set = Post.all
 query_set.prefetch(:author__favorite_tags)
+```
+
+In some situations it might be necessary to use a custom set for the prefetched records. This is possible by providing a `custom_query` argument:
+
+```crystal
+# Query all lists and order the list items by its position
+query_set = List.prefetch(:items, query_set: Item.order(:position))
 ```
 
 Finally, it is worth mentioning that multiple relations can be specified to `#prefetch`. For example:

--- a/docs/docs/models-and-databases/reference/query-set.md
+++ b/docs/docs/models-and-databases/reference/query-set.md
@@ -262,7 +262,7 @@ query_set = Post.all
 query_set.prefetch(:author__favorite_tags)
 ```
 
-In some situations it might be necessary to use a custom set for the prefetched records. This is possible by providing a `custom_query` argument:
+In some situations it might be necessary to use a custom query set for the prefetched records. This is possible by providing a `query_set` argument:
 
 ```crystal
 # Query all lists and order the list items by its position

--- a/spec/marten/db/model/querying_spec.cr
+++ b/spec/marten/db/model/querying_spec.cr
@@ -1103,6 +1103,88 @@ describe Marten::DB::Model::Querying do
       qset[1].get_related_object_variable(:user).should eq user_2
     end
 
+    it "allows to prefetch a single one-to-one relation with a custom query" do
+      user_1 = TestUser.create!(username: "jd1", email: "jd1@example.com", first_name: "John", last_name: "Doe")
+      user_2 = TestUser.create!(username: "jd2", email: "jd2@example.com", first_name: "John", last_name: "Doe")
+
+      user_profile_1 = TestUserProfile.create!(user: user_1, bio: "Test 1")
+      user_profile_2 = TestUserProfile.create!(user: user_2, bio: "Test 2")
+
+      qset = TestUserProfile.prefetch(:user, TestUser.filter(username: "jd1")).order(:bio)
+
+      qset.to_a.should eq [user_profile_1, user_profile_2]
+      qset[0].get_related_object_variable(:user).should eq user_1
+      qset[1].get_related_object_variable(:user).should be_nil
+    end
+
+    it "allows to prefetch a single many-to-one relation with a custom query" do
+      user_1 = TestUser.create!(username: "jd1", email: "jd1@example.com", first_name: "John", last_name: "Doe")
+      user_2 = TestUser.create!(username: "jd2", email: "jd2@example.com", first_name: "John", last_name: "Doe")
+
+      post_1 = Post.create!(author: user_1, title: "Post 1")
+      post_2 = Post.create!(author: user_2, title: "Post 2")
+
+      qset = Post.prefetch(:author, TestUser.filter(username: "jd1")).order(:title)
+
+      qset.to_a.should eq [post_1, post_2]
+      qset[0].get_related_object_variable(:author).should eq user_1
+      qset[1].get_related_object_variable(:author).should be_nil
+    end
+
+    it "allows to prefetch a single many-to-many relation with a custom query" do
+      tag_1 = Tag.create!(name: "ruby", is_active: true)
+      tag_2 = Tag.create!(name: "crystal", is_active: true)
+      tag_3 = Tag.create!(name: "coding", is_active: true)
+      tag_4 = Tag.create!(name: "programming", is_active: true)
+      tag_5 = Tag.create!(name: "typing", is_active: true)
+      Tag.create!(name: "debugging", is_active: true)
+
+      user_1 = TestUser.create!(username: "jd1", email: "jd1@example.com", first_name: "John", last_name: "Doe")
+      user_2 = TestUser.create!(username: "jd2", email: "jd2@example.com", first_name: "John", last_name: "Doe")
+      user_3 = TestUser.create!(username: "jd3", email: "jd3@example.com", first_name: "John", last_name: "Doe")
+
+      user_1.tags.add(tag_1, tag_3)
+      user_2.tags.add(tag_2, tag_3)
+      user_3.tags.add(tag_4, tag_5)
+
+      qset = TestUser.prefetch(:tags, Tag.order(:pk)).order(:username)
+
+      qset.to_a.should eq [user_1, user_2, user_3]
+      qset[0].tags.result_cache.should eq [tag_1, tag_3]
+      qset[1].tags.result_cache.should eq [tag_2, tag_3]
+      qset[2].tags.result_cache.should eq [tag_4, tag_5]
+    end
+
+    it "allows to prefetch a single reverse one-to-one relation with a custom query" do
+      user_1 = TestUser.create!(username: "jd1", email: "jd1@example.com", first_name: "John", last_name: "Doe")
+      user_2 = TestUser.create!(username: "jd2", email: "jd2@example.com", first_name: "John", last_name: "Doe")
+
+      user_profile_1 = TestUserProfile.create!(user: user_1, bio: "Test 1")
+      TestUserProfile.create!(user: user_2, bio: "Test 2")
+
+      qset = TestUser.prefetch(:profile, TestUserProfile.filter(bio: "Test 1")).order(:username)
+
+      qset.to_a.should eq [user_1, user_2]
+      qset[0].get_reverse_related_object_variable(:profile).should eq user_profile_1
+      qset[1].get_reverse_related_object_variable(:profile).should be_nil
+    end
+
+    it "allows to prefetch a single reverse many-to-one relation with a custom query" do
+      user_1 = TestUser.create!(username: "jd1", email: "jd1@example.com", first_name: "John", last_name: "Doe")
+      user_2 = TestUser.create!(username: "jd2", email: "jd2@example.com", first_name: "John", last_name: "Doe")
+
+      post_1 = Post.create!(author: user_1, title: "Post 1")
+      post_2 = Post.create!(author: user_2, title: "Post 2")
+      post_3 = Post.create!(author: user_1, title: "Post 3")
+      post_4 = Post.create!(author: user_2, title: "Post 4")
+
+      qset = TestUser.prefetch(:posts, Post.order("-pk")).order(:username)
+
+      qset.to_a.should eq [user_1, user_2]
+      qset[0].posts.result_cache.should eq [post_3, post_1]
+      qset[1].posts.result_cache.should eq [post_4, post_2]
+    end
+
     it "allows to prefetch a single reverse many-to-many relation with a custom query" do
       tag_1 = Tag.create!(name: "ruby", is_active: true)
       tag_2 = Tag.create!(name: "crystal", is_active: true)
@@ -1135,6 +1217,43 @@ describe Marten::DB::Model::Querying do
       qset[0].tags.result_cache.should eq [tag_2]
       qset[1].tags.result_cache.should eq [tag_2]
       qset[2].tags.result_cache.not_nil!.empty?.should be_true
+    end
+
+    it "can prefetch many relations with a custom query" do
+      tag_1 = Tag.create!(name: "ruby", is_active: true)
+      tag_2 = Tag.create!(name: "crystal", is_active: true)
+      tag_3 = Tag.create!(name: "coding", is_active: true)
+      tag_4 = Tag.create!(name: "programming", is_active: true)
+      tag_5 = Tag.create!(name: "typing", is_active: true)
+      Tag.create!(name: "debugging", is_active: true)
+
+      user_1 = TestUser.create!(username: "jd1", email: "jd1@example.com", first_name: "John", last_name: "Doe")
+      user_2 = TestUser.create!(username: "jd2", email: "jd2@example.com", first_name: "John", last_name: "Doe")
+      user_3 = TestUser.create!(username: "jd3", email: "jd3@example.com", first_name: "John", last_name: "Doe")
+
+      user_1.tags.add(tag_1, tag_3)
+      user_2.tags.add(tag_2, tag_3)
+      user_3.tags.add(tag_4, tag_5)
+
+      post_1 = Post.create!(author: user_1, title: "Post 1")
+      Post.create!(author: user_2, title: "Post 2")
+      Post.create!(author: user_1, title: "Post 3")
+      Post.create!(author: user_2, title: "Post 4")
+
+      qset = TestUser
+        .prefetch(:tags, Tag.filter(name: "crystal"))
+        .prefetch(:posts, Post.filter(title: "Post 1"))
+        .order(:username)
+
+      qset.to_a.should eq [user_1, user_2, user_3]
+
+      qset[0].tags.result_cache.try(&.sort_by(&.pk!)).try(&.empty?).should be_true
+      qset[1].tags.result_cache.try(&.sort_by(&.pk!)).should eq [tag_2]
+      qset[2].tags.result_cache.try(&.sort_by(&.pk!)).try(&.empty?).should be_true
+
+      qset[0].posts.result_cache.try(&.sort_by(&.pk!)).should eq [post_1]
+      qset[1].posts.result_cache.try(&.empty?).should be_true
+      qset[2].posts.result_cache.try(&.empty?).should be_true
     end
   end
 

--- a/spec/marten/db/query/prefetcher_spec.cr
+++ b/spec/marten/db/query/prefetcher_spec.cr
@@ -1955,7 +1955,7 @@ describe Marten::DB::Query::Prefetcher do
           using: nil,
           custom_query_sets: {
             "authors" => Marten::DB::Query::PrefetcherSpec::Author
-              .filter(name__contains: "Muster").as(Marten::DB::Query::Set::AnyQuerySet),
+              .filter(name__contains: "Muster").as(Marten::DB::Query::Set::Any),
           }
         )
 
@@ -1990,7 +1990,7 @@ describe Marten::DB::Query::Prefetcher do
           using: nil,
           custom_query_sets: {
             "conferences" => Marten::DB::Query::PrefetcherSpec::Conference
-              .filter(name__contains: "Crystal").as(Marten::DB::Query::Set::AnyQuerySet),
+              .filter(name__contains: "Crystal").as(Marten::DB::Query::Set::Any),
           }
         )
 
@@ -2018,7 +2018,7 @@ describe Marten::DB::Query::Prefetcher do
           using: nil,
           custom_query_sets: {
             "authors" => Marten::DB::Query::PrefetcherSpec::Bio
-              .filter(content__contains: "Muster").as(Marten::DB::Query::Set::AnyQuerySet),
+              .filter(content__contains: "Muster").as(Marten::DB::Query::Set::Any),
           }
         )
 

--- a/spec/marten/db/query/prefetcher_spec.cr
+++ b/spec/marten/db/query/prefetcher_spec.cr
@@ -2023,7 +2023,7 @@ describe Marten::DB::Query::Prefetcher do
         )
 
         expect_raises(
-          Marten::DB::Errors::MismatchedQuerySetType,
+          Marten::DB::Errors::UnmetQuerySetCondition,
           "Can't prefetch :authors using Marten::DB::Query::PrefetcherSpec::Bio query set"
         ) do
           prefetcher.execute

--- a/spec/marten/db/query/prefetcher_spec.cr
+++ b/spec/marten/db/query/prefetcher_spec.cr
@@ -1930,6 +1930,105 @@ describe Marten::DB::Query::Prefetcher do
         records[4].books.result_cache.try(&.sort_by(&.pk!.to_s)).should eq [book_3]
         records[5].books.result_cache.try(&.empty?).should be_true
       end
+
+      it "uses a custom query set that filters records when prefetching" do
+        author_1 = Marten::DB::Query::PrefetcherSpec::Author.create!(name: "Abc Doe")
+        author_2 = Marten::DB::Query::PrefetcherSpec::Author.create!(name: "Def Doe")
+        author_3 = Marten::DB::Query::PrefetcherSpec::Author.create!(name: "Ghi Muster")
+        author_4 = Marten::DB::Query::PrefetcherSpec::Author.create!(name: "Jkl Doe")
+        author_5 = Marten::DB::Query::PrefetcherSpec::Author.create!(name: "Mno Muster")
+        Marten::DB::Query::PrefetcherSpec::Author.create!(name: "Pqr Doe")
+
+        book_1 = Marten::DB::Query::PrefetcherSpec::Book.create!(title: "Abc")
+        book_2 = Marten::DB::Query::PrefetcherSpec::Book.create!(title: "Def")
+        book_3 = Marten::DB::Query::PrefetcherSpec::Book.create!(title: "Ghi")
+
+        book_1.authors.add(author_1, author_3)
+        book_2.authors.add(author_2, author_3)
+        book_3.authors.add(author_4, author_5)
+
+        records = Marten::DB::Query::PrefetcherSpec::Book.order(:pk).to_a
+
+        prefetcher = Marten::DB::Query::Prefetcher.new(
+          records: Array(Marten::DB::Model).new.concat(records),
+          relations: ["authors"],
+          using: nil,
+          custom_query_sets: {
+            "authors" => Marten::DB::Query::PrefetcherSpec::Author
+              .filter(name__contains: "Muster").as(Marten::DB::Query::Set::AnyQuerySet),
+          }
+        )
+
+        expect_db_query_count(2) { prefetcher.execute }
+
+        records[0].authors.result_cache.should eq [author_3]
+        records[1].authors.result_cache.should eq [author_3]
+        records[2].authors.result_cache.should eq [author_5]
+      end
+
+      it "doesn't use a custom query if none is specified for that relation" do
+        author_1 = Marten::DB::Query::PrefetcherSpec::Author.create!(name: "Abc Doe")
+        author_2 = Marten::DB::Query::PrefetcherSpec::Author.create!(name: "Def Doe")
+        author_3 = Marten::DB::Query::PrefetcherSpec::Author.create!(name: "Ghi Muster")
+        author_4 = Marten::DB::Query::PrefetcherSpec::Author.create!(name: "Jkl Doe")
+        author_5 = Marten::DB::Query::PrefetcherSpec::Author.create!(name: "Mno Muster")
+        Marten::DB::Query::PrefetcherSpec::Author.create!(name: "Pqr Doe")
+
+        book_1 = Marten::DB::Query::PrefetcherSpec::Book.create!(title: "Abc")
+        book_2 = Marten::DB::Query::PrefetcherSpec::Book.create!(title: "Def")
+        book_3 = Marten::DB::Query::PrefetcherSpec::Book.create!(title: "Ghi")
+
+        book_1.authors.add(author_1, author_3)
+        book_2.authors.add(author_2, author_3)
+        book_3.authors.add(author_4, author_5)
+
+        records = Marten::DB::Query::PrefetcherSpec::Book.order(:pk).to_a
+
+        prefetcher = Marten::DB::Query::Prefetcher.new(
+          records: Array(Marten::DB::Model).new.concat(records),
+          relations: ["authors"],
+          using: nil,
+          custom_query_sets: {
+            "conferences" => Marten::DB::Query::PrefetcherSpec::Conference
+              .filter(name__contains: "Crystal").as(Marten::DB::Query::Set::AnyQuerySet),
+          }
+        )
+
+        expect_db_query_count(2) { prefetcher.execute }
+
+        records[0].authors.result_cache.should eq [author_1, author_3]
+        records[1].authors.result_cache.should eq [author_2, author_3]
+        records[2].authors.result_cache.should eq [author_4, author_5]
+      end
+
+      it "raises if an incompatible query set is used for the custom query" do
+        author_1 = Marten::DB::Query::PrefetcherSpec::Author.create!(name: "Abc Doe")
+        author_2 = Marten::DB::Query::PrefetcherSpec::Author.create!(name: "Def Doe")
+        Marten::DB::Query::PrefetcherSpec::Author.create!(name: "Pqr Doe")
+
+        book_1 = Marten::DB::Query::PrefetcherSpec::Book.create!(title: "Abc")
+
+        book_1.authors.add(author_1, author_2)
+
+        records = Marten::DB::Query::PrefetcherSpec::Book.order(:pk).to_a
+
+        prefetcher = Marten::DB::Query::Prefetcher.new(
+          records: Array(Marten::DB::Model).new.concat(records),
+          relations: ["authors"],
+          using: nil,
+          custom_query_sets: {
+            "authors" => Marten::DB::Query::PrefetcherSpec::Bio
+              .filter(content__contains: "Muster").as(Marten::DB::Query::Set::AnyQuerySet),
+          }
+        )
+
+        expect_raises(
+          Marten::DB::Errors::MismatchedQuerySetType,
+          "Can't prefetch :authors using Marten::DB::Query::PrefetcherSpec::Bio query set"
+        ) do
+          prefetcher.execute
+        end
+      end
     end
   end
 end

--- a/spec/marten/db/query/prefetcher_spec.cr
+++ b/spec/marten/db/query/prefetcher_spec.cr
@@ -2024,7 +2024,7 @@ describe Marten::DB::Query::Prefetcher do
 
         expect_raises(
           Marten::DB::Errors::UnmetQuerySetCondition,
-          "Can't prefetch :authors using Marten::DB::Query::PrefetcherSpec::Bio query set"
+          "Cannot prefetch 'authors' relation using a Marten::DB::Query::PrefetcherSpec::Bio query set."
         ) do
           prefetcher.execute
         end

--- a/spec/marten/db/query/set_spec.cr
+++ b/spec/marten/db/query/set_spec.cr
@@ -3332,7 +3332,7 @@ describe Marten::DB::Query::Set do
 
       expect_raises(
         Marten::DB::Errors::UnmetQuerySetCondition,
-        "Can't prefetch :tags using TestUser query set."
+        "Cannot prefetch 'tags' relation using a TestUser query set."
       ) do
         qset.to_a
       end

--- a/spec/marten/db/query/set_spec.cr
+++ b/spec/marten/db/query/set_spec.cr
@@ -3189,20 +3189,34 @@ describe Marten::DB::Query::Set do
       qset[1].get_related_object_variable(:user).should eq user_2
     end
 
-    it "allows to prefetch a single reverse many-to-one relation with a custom query" do
+    it "allows to prefetch a single one-to-one relation with a custom query" do
+      user_1 = TestUser.create!(username: "jd1", email: "jd1@example.com", first_name: "John", last_name: "Doe")
+      user_2 = TestUser.create!(username: "jd2", email: "jd2@example.com", first_name: "John", last_name: "Doe")
+
+      user_profile_1 = TestUserProfile.create!(user: user_1, bio: "Test 1")
+      user_profile_2 = TestUserProfile.create!(user: user_2, bio: "Test 2")
+
+      qset = Marten::DB::Query::Set(TestUserProfile)
+        .new.order(:bio).prefetch(:user, TestUser.filter(username: "jd1"))
+
+      qset.to_a.should eq [user_profile_1, user_profile_2]
+      qset[0].get_related_object_variable(:user).should eq user_1
+      qset[1].get_related_object_variable(:user).should be_nil
+    end
+
+    it "allows to prefetch a single many-to-one relation with a custom query" do
       user_1 = TestUser.create!(username: "jd1", email: "jd1@example.com", first_name: "John", last_name: "Doe")
       user_2 = TestUser.create!(username: "jd2", email: "jd2@example.com", first_name: "John", last_name: "Doe")
 
       post_1 = Post.create!(author: user_1, title: "Post 1")
       post_2 = Post.create!(author: user_2, title: "Post 2")
-      post_3 = Post.create!(author: user_1, title: "Post 3")
-      post_4 = Post.create!(author: user_2, title: "Post 4")
 
-      qset = Marten::DB::Query::Set(TestUser).new.order(:username).prefetch(:posts, Post.order("-pk"))
+      qset = Marten::DB::Query::Set(Post)
+        .new.order(:title).prefetch(:author, TestUser.filter(username: "jd1"))
 
-      qset.to_a.should eq [user_1, user_2]
-      qset[0].posts.result_cache.should eq [post_3, post_1]
-      qset[1].posts.result_cache.should eq [post_4, post_2]
+      qset.to_a.should eq [post_1, post_2]
+      qset[0].get_related_object_variable(:author).should eq user_1
+      qset[1].get_related_object_variable(:author).should be_nil
     end
 
     it "allows to prefetch a single many-to-many relation with a custom query" do
@@ -3228,15 +3242,74 @@ describe Marten::DB::Query::Set do
       qset[0].tags.result_cache.try(&.sort_by(&.pk!)).should eq [tag_1]
       qset[1].tags.result_cache.try(&.sort_by(&.pk!)).should eq [tag_2]
       qset[2].tags.result_cache.not_nil!.empty?.should be_true
+    end
 
-      # The other way around
-      qset = Marten::DB::Query::Set(Tag).new.order(:pk).prefetch(:test_users, TestUser.filter(first_name: "John"))
-      qset[0].test_users.result_cache.try(&.sort_by(&.pk!)).should eq [user_1]
-      qset[1].test_users.result_cache.not_nil!.empty?.should be_true
-      qset[2].test_users.result_cache.try(&.sort_by(&.pk!)).should eq [user_1]
-      qset[3].test_users.result_cache.try(&.sort_by(&.pk!)).should eq [user_3]
-      qset[4].test_users.result_cache.try(&.sort_by(&.pk!)).should eq [user_3]
-      qset[5].test_users.result_cache.not_nil!.empty?.should be_true
+    it "allows to prefetch a single reverse one-to-one relation with a custom query" do
+      user_1 = TestUser.create!(username: "jd1", email: "jd1@example.com", first_name: "John", last_name: "Doe")
+      user_2 = TestUser.create!(username: "jd2", email: "jd2@example.com", first_name: "John", last_name: "Doe")
+
+      user_profile_1 = TestUserProfile.create!(user: user_1, bio: "Test 1")
+      TestUserProfile.create!(user: user_2, bio: "Test 2")
+
+      qset = Marten::DB::Query::Set(TestUser)
+        .new.order(:username).prefetch(:profile, TestUserProfile.filter(bio: "Test 1"))
+
+      qset.to_a.should eq [user_1, user_2]
+      qset[0].get_reverse_related_object_variable(:profile).should eq user_profile_1
+      qset[1].get_reverse_related_object_variable(:profile).should be_nil
+    end
+
+    it "allows to prefetch a single reverse many-to-one relation with a custom query" do
+      user_1 = TestUser.create!(username: "jd1", email: "jd1@example.com", first_name: "John", last_name: "Doe")
+      user_2 = TestUser.create!(username: "jd2", email: "jd2@example.com", first_name: "John", last_name: "Doe")
+
+      post_1 = Post.create!(author: user_1, title: "Post 1")
+      post_2 = Post.create!(author: user_2, title: "Post 2")
+      post_3 = Post.create!(author: user_1, title: "Post 3")
+      post_4 = Post.create!(author: user_2, title: "Post 4")
+
+      qset = Marten::DB::Query::Set(TestUser).new.order(:username).prefetch(:posts, Post.order("-pk"))
+
+      qset.to_a.should eq [user_1, user_2]
+      qset[0].posts.result_cache.should eq [post_3, post_1]
+      qset[1].posts.result_cache.should eq [post_4, post_2]
+    end
+
+    it "can prefetch many relations with a custom query" do
+      tag_1 = Tag.create!(name: "ruby", is_active: true)
+      tag_2 = Tag.create!(name: "crystal", is_active: true)
+      tag_3 = Tag.create!(name: "coding", is_active: true)
+      tag_4 = Tag.create!(name: "programming", is_active: true)
+      tag_5 = Tag.create!(name: "typing", is_active: true)
+      Tag.create!(name: "debugging", is_active: true)
+
+      user_1 = TestUser.create!(username: "jd1", email: "jd1@example.com", first_name: "John", last_name: "Doe")
+      user_2 = TestUser.create!(username: "jd2", email: "jd2@example.com", first_name: "John", last_name: "Doe")
+      user_3 = TestUser.create!(username: "jd3", email: "jd3@example.com", first_name: "John", last_name: "Doe")
+
+      user_1.tags.add(tag_1, tag_3)
+      user_2.tags.add(tag_2, tag_3)
+      user_3.tags.add(tag_4, tag_5)
+
+      post_1 = Post.create!(author: user_1, title: "Post 1")
+      post_2 = Post.create!(author: user_2, title: "Post 2")
+      post_3 = Post.create!(author: user_1, title: "Post 3")
+      post_4 = Post.create!(author: user_2, title: "Post 4")
+
+      qset = Marten::DB::Query::Set(TestUser)
+        .new.order(:username)
+        .prefetch(:tags, Tag.order("pk"))
+        .prefetch(:posts, Post.order("pk"))
+
+      qset.to_a.should eq [user_1, user_2, user_3]
+
+      qset[0].tags.result_cache.should eq [tag_1, tag_3]
+      qset[1].tags.result_cache.should eq [tag_2, tag_3]
+      qset[2].tags.result_cache.should eq [tag_4, tag_5]
+
+      qset[0].posts.result_cache.should eq [post_1, post_3]
+      qset[1].posts.result_cache.should eq [post_2, post_4]
+      qset[2].posts.result_cache.try(&.empty?).should be_true
     end
 
     it "raises if an incompatible query set is used for the custom query" do

--- a/spec/marten/db/query/set_spec.cr
+++ b/spec/marten/db/query/set_spec.cr
@@ -3331,7 +3331,7 @@ describe Marten::DB::Query::Set do
       qset = Marten::DB::Query::Set(TestUser).new.order(:username).prefetch(:tags, TestUser.filter(username: "jd1"))
 
       expect_raises(
-        Marten::DB::Errors::MismatchedQuerySetType,
+        Marten::DB::Errors::UnmetQuerySetCondition,
         "Can't prefetch :tags using TestUser query set."
       ) do
         qset.to_a

--- a/src/marten/db/errors.cr
+++ b/src/marten/db/errors.cr
@@ -4,6 +4,9 @@ module Marten
       # Represents an error raised when a specific predicate will return an empty result set.
       class EmptyResults < Exception; end
 
+      # Represents an error raised when using incompatible query sets.
+      class MismatchedQuerySetType < Exception; end
+
       # Represents an error raised when a problem is detected with a specific model field.
       class InvalidField < Exception; end
 

--- a/src/marten/db/errors.cr
+++ b/src/marten/db/errors.cr
@@ -4,9 +4,6 @@ module Marten
       # Represents an error raised when a specific predicate will return an empty result set.
       class EmptyResults < Exception; end
 
-      # Represents an error raised when using incompatible query sets.
-      class MismatchedQuerySetType < Exception; end
-
       # Represents an error raised when a problem is detected with a specific model field.
       class InvalidField < Exception; end
 

--- a/src/marten/db/model/querying.cr
+++ b/src/marten/db/model/querying.cr
@@ -783,7 +783,7 @@ module Marten
           #
           # It should be noted that this method enforces type-checking for the custom queryset to ensure its
           # model matches the relation being prefetched. If a type mismatch is detected, a
-          # `Marten::DB::Errors::MismatchedQuerySetType` exception will be raised. For example:
+          # `Marten::DB::Errors::UnmetQuerySetCondition` exception will be raised. For example:
           #
           # ```
           # # Valid usage
@@ -791,7 +791,7 @@ module Marten
           #
           # # Invalid usage: Type mismatch
           # posts = Post.all.prefetch(:tags, query_set: Comment.order(:created_at))
-          # # Raises Marten::DB::Errors::MismatchedQuerySetType:
+          # # Raises Marten::DB::Errors::UnmetQuerySetCondition:
           # # "Can't prefetch :tags using Comment query set."
           # ```
           def prefetch(relation_name : String | Symbol, query_set : Query::Set::AnyQuerySet)

--- a/src/marten/db/model/querying.cr
+++ b/src/marten/db/model/querying.cr
@@ -770,7 +770,31 @@ module Marten
             all.prefetch(*relations)
           end
 
-          def prefetch(relation_name : String | Symbol, query_set : Query::Set::AnyQuerySet | Nil = nil)
+          # Returns a queryset that will automatically prefetch in a single batch the records for the
+          # specified relation, with a custom queryset to control how the related records are queried.
+          # The prefetched records will be populated on the returned queryset. Using this method can result in
+          # performance improvements by reducing the number of SQL queries, as illustrated by the following example:
+          #
+          # ```
+          # # Prefetching with a custom queryset
+          # posts = Post.all.prefetch(:tags, query_set: Tag.order(:name)).to_a
+          # puts posts[0].tags # Prefetched with custom ordering
+          # ```
+          #
+          # It should be noted that this method enforces type-checking for the custom queryset to ensure its
+          # model matches the relation being prefetched. If a type mismatch is detected, a
+          # `Marten::DB::Errors::MismatchedQuerySetType` exception will be raised. For example:
+          #
+          # ```
+          # # Valid usage
+          # posts = Post.all.prefetch(:tags, query_set: Tag.order(:name))
+          #
+          # # Invalid usage: Type mismatch
+          # posts = Post.all.prefetch(:tags, query_set: Comment.order(:created_at))
+          # # Raises Marten::DB::Errors::MismatchedQuerySetType:
+          # # "Can't prefetch :tags using Comment query set."
+          # ```
+          def prefetch(relation_name : String | Symbol, query_set : Query::Set::AnyQuerySet)
             all.prefetch(relation_name, query_set)
           end
 

--- a/src/marten/db/model/querying.cr
+++ b/src/marten/db/model/querying.cr
@@ -770,6 +770,10 @@ module Marten
             all.prefetch(*relations)
           end
 
+          def prefetch(relation_name : String | Symbol, query_set : Query::Set::AnyQuerySet | Nil = nil)
+            all.prefetch(relation_name, query_set)
+          end
+
           # Returns a raw query set for the passed SQL query and optional positional parameters.
           #
           # This method returns a `Marten::DB::Query::RawSet` object, which allows to iterate over the model records
@@ -971,9 +975,10 @@ module Marten
               class ::{{ @type }}::QuerySet < Marten::DB::Query::Set({{ @type }})
                 def initialize(
                   @query = Marten::DB::Query::SQL::Query({{ @type }}).new,
-                  @prefetched_relations = [] of ::String
+                  @prefetched_relations = [] of ::String,
+                  @custom_query_sets  = {} of ::String => AnyQuerySet
                 )
-                  super(@query, @prefetched_relations)
+                  super(@query, @prefetched_relations, @custom_query_sets)
                 end
 
                 {% for queryset_id, block in MODEL_SCOPES[:custom] %}
@@ -986,6 +991,7 @@ module Marten
                   ::{{ @type }}::QuerySet.new(
                     other_query.nil? ? @query.clone : other_query.not_nil!,
                     prefetched_relations,
+                    custom_query_sets
                   )
                 end
               end

--- a/src/marten/db/model/querying.cr
+++ b/src/marten/db/model/querying.cr
@@ -794,7 +794,7 @@ module Marten
           # # Raises Marten::DB::Errors::UnmetQuerySetCondition:
           # # "Can't prefetch :tags using Comment query set."
           # ```
-          def prefetch(relation_name : String | Symbol, query_set : Query::Set::AnyQuerySet)
+          def prefetch(relation_name : String | Symbol, query_set : Query::Set::Any)
             all.prefetch(relation_name, query_set)
           end
 
@@ -1000,7 +1000,7 @@ module Marten
                 def initialize(
                   @query = Marten::DB::Query::SQL::Query({{ @type }}).new,
                   @prefetched_relations = [] of ::String,
-                  @custom_query_sets  = {} of ::String => AnyQuerySet
+                  @custom_query_sets  = {} of ::String => Any
                 )
                   super(@query, @prefetched_relations, @custom_query_sets)
                 end

--- a/src/marten/db/query/prefetcher.cr
+++ b/src/marten/db/query/prefetcher.cr
@@ -171,7 +171,7 @@ module Marten
           records_to_decorate
         end
 
-        private def prefetch_query_set(relation_name, default_model)
+        private def query_set_for_prefetched_relation(relation_name, default_model)
           if custom_query = @custom_query_sets[relation_name]?
             raise Errors::UnmetQuerySetCondition.new(
               "Cannot prefetch '#{relation_name}' relation using a #{custom_query.model.name} query set."
@@ -189,7 +189,7 @@ module Marten
         ) : Array(Model)
           prefetched_records = Array(Model).new
 
-          query_set = prefetch_query_set(relation_name, context.field.related_model)
+          query_set = query_set_for_prefetched_relation(relation_name, context.field.related_model)
 
           if context.field.is_a?(Field::ManyToOne) || context.field.is_a?(Field::OneToOne)
             prefetched_records_pks = records_to_decorate.compact_map(&.get_field_value(context.field.id))
@@ -234,7 +234,7 @@ module Marten
         ) : Array(Model)
           prefetched_records = Array(Model).new
 
-          query_set = prefetch_query_set(relation_name, context.reverse_relation.model)
+          query_set = query_set_for_prefetched_relation(relation_name, context.reverse_relation.model)
 
           if context.reverse_relation.one_to_one?
             prefetched_records.concat(

--- a/src/marten/db/query/prefetcher.cr
+++ b/src/marten/db/query/prefetcher.cr
@@ -14,7 +14,7 @@ module Marten
           @records : Array(Model),
           @relations : Array(String),
           @using : String?,
-          @custom_query_sets : Hash(String, Set::AnyQuerySet) = {} of String => Set::AnyQuerySet,
+          @custom_query_sets : Hash(String, Set::Any) = {} of String => Set::Any,
         )
         end
 
@@ -298,7 +298,7 @@ module Marten
           relation_name : String,
           m2m_field : Field::ManyToMany,
           records_to_decorate : Array(Model),
-          query_set : Set::AnyQuerySet,
+          query_set : Set::Any,
           forward : Bool,
         ) : Array(Model)
           # Retrieve the through records in order to get the related records.

--- a/src/marten/db/query/prefetcher.cr
+++ b/src/marten/db/query/prefetcher.cr
@@ -173,7 +173,7 @@ module Marten
 
         private def prefetch_query_set(relation_name, default_model)
           if custom_query = @custom_query_sets[relation_name]?
-            raise Errors::MismatchedQuerySetType.new(
+            raise Errors::UnmetQuerySetCondition.new(
               "Can't prefetch :#{relation_name} using #{custom_query.model} query set."
             ) if custom_query.model != default_model
             custom_query

--- a/src/marten/db/query/prefetcher.cr
+++ b/src/marten/db/query/prefetcher.cr
@@ -174,7 +174,7 @@ module Marten
         private def prefetch_query_set(relation_name, default_model)
           if custom_query = @custom_query_sets[relation_name]?
             raise Errors::UnmetQuerySetCondition.new(
-              "Can't prefetch :#{relation_name} using #{custom_query.model} query set."
+              "Cannot prefetch '#{relation_name}' relation using a #{custom_query.model.name} query set."
             ) if custom_query.model != default_model
             custom_query
           else

--- a/src/marten/db/query/set.cr
+++ b/src/marten/db/query/set.cr
@@ -1187,7 +1187,31 @@ module Marten
           qs
         end
 
-        def prefetch(relation_name : String | Symbol, query_set : AnyQuerySet | Nil)
+        # Returns a queryset that will automatically prefetch in a single batch the records for the specified relation,
+        # with a custom queryset to control how the related records are queried. The prefetched records will be
+        # populated on the returned queryset. Using this method can result in performance improvements by reducing
+        # the number of SQL queries, as illustrated by the following example:
+        #
+        # ```
+        # # Prefetching with a custom queryset
+        # posts = Post.all.prefetch(:tags, query_set: Tag.order(:name)).to_a
+        # puts posts[0].tags # Prefetched with custom ordering
+        # ```
+        #
+        # It should be noted that this method enforces type-checking for the custom queryset to ensure its model matches
+        # the relation being prefetched. If a type mismatch is detected, a `Marten::DB::Errors::MismatchedQuerySetType`
+        # exception will be raised. For example:
+        #
+        # ```
+        # # Valid usage
+        # posts = Post.all.prefetch(:tags, query_set: Tag.order(:name))
+        #
+        # # Invalid usage: Type mismatch
+        # posts = Post.all.prefetch(:tags, query_set: Comment.order(:created_at))
+        # # Raises Marten::DB::Errors::MismatchedQuerySetType:
+        # # "Can't prefetch :tags using Comment query set."
+        # ```
+        def prefetch(relation_name : String | Symbol, query_set : AnyQuerySet)
           qs = clone
           relation_name = relation_name.to_s
           qs.prefetched_relations << relation_name

--- a/src/marten/db/query/set.cr
+++ b/src/marten/db/query/set.cr
@@ -1212,12 +1212,11 @@ module Marten
         # # "Can't prefetch :tags using Comment query set."
         # ```
         def prefetch(relation_name : String | Symbol, query_set : Any)
-          qs = clone
           relation_name = relation_name.to_s
+
+          qs = clone
           qs.prefetched_relations << relation_name
-
-          qs.custom_query_sets[relation_name] = query_set if query_set
-
+          qs.custom_query_sets[relation_name] = query_set
           qs
         end
 
@@ -1512,17 +1511,16 @@ module Marten
           qs
         end
 
-
-        # Creates an alias `Any` representing the query sets of all existing models.
-        #
-        # For example, if you have the models `User` and `Post`,
-        # then this macro will generate:
-        #
-        #   alias Any = Set(User) | Set(Post)
-        #
-        # That means anywhere in your code where you accept `Any`, you accept
-        # any `Set(M)` specialized to these models.
         macro finished
+          # Creates an alias `Any` representing the query sets of all existing models.
+          #
+          # For example, if you have the models `User` and `Post`,
+          # then this macro will generate:
+          #
+          #   alias Any = Set(User) | Set(Post)
+          #
+          # That means anywhere in your code where you accept `Any`, you accept
+          # any `Set(M)` specialized to these models.
           {% model_types = Marten::DB::Model.all_subclasses.reject(&.abstract?).map(&.name) %}
           {% if model_types.size > 0 %}
             alias Any = {% for t, i in model_types %}Set({{ t }}){% if i + 1 < model_types.size %} | {% end %}{% end %}

--- a/src/marten/db/query/set.cr
+++ b/src/marten/db/query/set.cr
@@ -1199,7 +1199,7 @@ module Marten
         # ```
         #
         # It should be noted that this method enforces type-checking for the custom queryset to ensure its model matches
-        # the relation being prefetched. If a type mismatch is detected, a `Marten::DB::Errors::MismatchedQuerySetType`
+        # the relation being prefetched. If a type mismatch is detected, a `Marten::DB::Errors::UnmetQuerySetCondition`
         # exception will be raised. For example:
         #
         # ```
@@ -1208,7 +1208,7 @@ module Marten
         #
         # # Invalid usage: Type mismatch
         # posts = Post.all.prefetch(:tags, query_set: Comment.order(:created_at))
-        # # Raises Marten::DB::Errors::MismatchedQuerySetType:
+        # # Raises Marten::DB::Errors::UnmetQuerySetCondition:
         # # "Can't prefetch :tags using Comment query set."
         # ```
         def prefetch(relation_name : String | Symbol, query_set : AnyQuerySet)


### PR DESCRIPTION
This change introduces the option to provide a custom query for `#prefetch`, e.g.:

```crystal
qs = List.prefetch(:items, Item.order(:position))
```

The type of custom query must match the related type, otherwise an exception is thrown.

#264 