### PR TITLE
Fix `blank: true` description

### DIFF
--- a/docs/docs/models-and-databases/validations.md
+++ b/docs/docs/models-and-databases/validations.md
@@ -69,7 +69,7 @@ user.invalid?   # => true
 As mentioned previously, fields can contribute validation rules to your models. These validation rules can be inherited:
 
 * from the field type itself: some fields will validate that values are of a specific type (for example a `uuid` field will not validate values that don't correspond to valid UUIDs)
-* from the field options you define (for example fields using `blank: true` won't accept empty values)
+* from the field options you define (for example fields using `blank: true` accept empty values)
 
 Please refer to the [fields reference](./reference/fields.md) in order to learn more about the supported field types and their associated options.
 


### PR DESCRIPTION
While reading [Field validation rules](https://martenframework.com/docs/models-and-databases/validations#field-validation-rules), I found a statement that appears to be incorrect.

- fields using `blank: true` won't accept empty values

This contradicts the explanation in [fields#blank](https://martenframework.com/docs/models-and-databases/reference/fields#blank).

The correct explanation should be either
- fields using `blank: true` accept empty values
- fields using `blank: false` won't accept empty values

The latter is described earlier in this document, so I have fixed the explanation for `blank: true`.