### PR TITLE
Support requests with `Content-Type: application/json` and empty body

### DIFF
--- a/spec/marten/http/request_spec.cr
+++ b/spec/marten/http/request_spec.cr
@@ -302,6 +302,32 @@ describe Marten::HTTP::Request do
       request.data.fetch_all("test").should eq ["xyz"]
     end
 
+    it "returns empty object if application/json inputs is empty on POST" do
+      request = Marten::HTTP::Request.new(
+        ::HTTP::Request.new(
+          method: "POST",
+          resource: "/test/xyz",
+          headers: HTTP::Headers{"Host" => "example.com", "Content-Type" => "application/json"},
+          body: %{}
+        )
+      )
+      request.data.should be_a Marten::HTTP::Params::Data
+      request.data.size.should eq 0
+    end
+
+    it "returns empty object if application/json inputs is empty on GET" do
+      request = Marten::HTTP::Request.new(
+        ::HTTP::Request.new(
+          method: "GET",
+          resource: "/test/xyz",
+          headers: HTTP::Headers{"Host" => "example.com", "Content-Type" => "application/json"},
+          body: %{}
+        )
+      )
+      request.data.should be_a Marten::HTTP::Params::Data
+      request.data.size.should eq 0
+    end
+
     it "returns an object without parsed params if the content type is not supported" do
       request = Marten::HTTP::Request.new(
         ::HTTP::Request.new(

--- a/src/marten/http/request.cr
+++ b/src/marten/http/request.cr
@@ -338,7 +338,7 @@ module Marten
             end
           end
         elsif content_type?(CONTENT_TYPE_APPLICATION_JSON)
-          if !(json_params = JSON.parse(body).as_h?).nil?
+          if !body.blank? && !(json_params = JSON.parse(body).as_h?).nil?
             json_params.each do |key, value|
               params[key] = [] of Params::Data::Value unless params.has_key?(key)
               params[key].as(Params::Data::Values) << value


### PR DESCRIPTION
This change fixes an issue where GET/POST requests with the `Content-Type: application/json` header
and an empty body would raise a `JSON::ParseException: unexpected token '<EOF>' at line 1, column 1.`

The fix adds a check to ensure the request body is not empty before attempting to parse it as JSON.

<details><summary>Exception details</summary>
<pre>
unexpected token '<EOF>' at line 1, column 1 (JSON::ParseException)
  from /opt/homebrew/Cellar/crystal/1.16.2/share/crystal/src/json/parser.cr:125:5 in 'parse_exception'
  from /opt/homebrew/Cellar/crystal/1.16.2/share/crystal/src/json/parser.cr:69 in 'unexpected_token'
  from /opt/homebrew/Cellar/crystal/1.16.2/share/crystal/src/json/parser.cr:37:7 in 'parse_value'
  from /opt/homebrew/Cellar/crystal/1.16.2/share/crystal/src/json/parser.cr:13:12 in 'parse'
  from /opt/homebrew/Cellar/crystal/1.16.2/share/crystal/src/json.cr:137:5 in 'parse'
  from lib/marten/src/marten/http/request.cr:341:30 in 'extract_raw_data_params'
  from lib/marten/src/marten/http/request.cr:64:19 in 'data'
  from lib/marten/src/marten/server/handlers/debug_logger.cr:13:15 in 'call'
  from /opt/homebrew/Cellar/crystal/1.16.2/share/crystal/src/http/server/handler.cr:30:7 in 'call_next'
  from /opt/homebrew/Cellar/crystal/1.16.2/share/crystal/src/http/server/handlers/error_handler.cr:18:5 in 'call'
  from /opt/homebrew/Cellar/crystal/1.16.2/share/crystal/src/http/server/request_processor.cr:51:11 in 'process'
  from /opt/homebrew/Cellar/crystal/1.16.2/share/crystal/src/http/server.cr:521:5 in 'handle_client'
  from /opt/homebrew/Cellar/crystal/1.16.2/share/crystal/src/http/server.cr:451:5 in '->'
  from /opt/homebrew/Cellar/crystal/1.16.2/share/crystal/src/fiber.cr:170:11 in 'run'
  from /opt/homebrew/Cellar/crystal/1.16.2/share/crystal/src/fiber.cr:105:3 in '->'
</pre>
</details> 