### PR TITLE
query: Add total_count method to support pagination

### DIFF
--- a/spec/marten/db/query/page_spec.cr
+++ b/spec/marten/db/query/page_spec.cr
@@ -112,6 +112,19 @@ describe Marten::DB::Query::Page do
     end
   end
 
+  describe "#total_count" do
+    it "returns the total number of records" do
+      Tag.create!(name: "a_tag", is_active: true)
+      Tag.create!(name: "b_tag", is_active: true)
+      Tag.create!(name: "c_tag", is_active: true)
+      Tag.create!(name: "d_tag", is_active: true)
+      Tag.create!(name: "e_tag", is_active: true)
+
+      paginator = Tag.all.order(:name).paginator(2)
+      paginator.page(2).total_count.should eq 5
+    end
+  end
+
   describe "#previous_page?" do
     it "returns true if there is a previous page number" do
       Tag.create!(name: "a_tag", is_active: true)

--- a/spec/marten/db/query/paginator_spec.cr
+++ b/spec/marten/db/query/paginator_spec.cr
@@ -144,7 +144,7 @@ describe Marten::DB::Query::Paginator do
       paginator.total_count.should eq 2
     end
 
-    it "returns the expected pages count if there are multiple pages" do
+    it "returns the total count if there are multiple pages" do
       Tag.create!(name: "a_tag", is_active: true)
       Tag.create!(name: "b_tag", is_active: true)
       Tag.create!(name: "c_tag", is_active: true)
@@ -152,7 +152,7 @@ describe Marten::DB::Query::Paginator do
       Tag.create!(name: "e_tag", is_active: true)
 
       paginator = Tag.all.order(:name).paginator(2)
-      paginator.pages_count.should eq 3
+      paginator.total_count.should eq 5
     end
   end
 end

--- a/spec/marten/db/query/paginator_spec.cr
+++ b/spec/marten/db/query/paginator_spec.cr
@@ -129,4 +129,30 @@ describe Marten::DB::Query::Paginator do
       paginator.pages_count.should eq 3
     end
   end
+
+  describe "#total_count" do
+    it "returns the expected pages count if there are no pages" do
+      paginator = Tag.all.order(:name).paginator(2)
+      paginator.total_count.should eq 0
+    end
+
+    it "returns two elements if there is only one page" do
+      Tag.create!(name: "a_tag", is_active: true)
+      Tag.create!(name: "b_tag", is_active: true)
+
+      paginator = Tag.all.order(:name).paginator(2)
+      paginator.total_count.should eq 2
+    end
+
+    it "returns the expected pages count if there are multiple pages" do
+      Tag.create!(name: "a_tag", is_active: true)
+      Tag.create!(name: "b_tag", is_active: true)
+      Tag.create!(name: "c_tag", is_active: true)
+      Tag.create!(name: "d_tag", is_active: true)
+      Tag.create!(name: "e_tag", is_active: true)
+
+      paginator = Tag.all.order(:name).paginator(2)
+      paginator.pages_count.should eq 3
+    end
+  end
 end

--- a/src/marten/db/query/page.cr
+++ b/src/marten/db/query/page.cr
@@ -36,6 +36,11 @@ module Marten
           paginator.pages_count
         end
 
+        # Returns the total number of records in the queryset, without applying pagination.
+        def total_count
+          paginator.total_count
+        end
+
         # Returns `true` if there is a previous page.
         def previous_page?
           number > 1

--- a/src/marten/db/query/paginator.cr
+++ b/src/marten/db/query/paginator.cr
@@ -13,6 +13,7 @@ module Marten
         class EmptyPageError < Exception; end
 
         @pages_count : Int32? = nil
+        @total_count : (Int32 | Int64 | Nil) = nil
 
         getter queryset
         getter page_size
@@ -44,7 +45,12 @@ module Marten
 
         # Returns the number of pages.
         def pages_count
-          @pages_count ||= ([1, queryset.size].max / page_size).ceil.to_i32
+          @pages_count ||= ([1, total_count].max / page_size).ceil.to_i32
+        end
+
+        # Returns the total number of records in the queryset, without applying pagination.
+        def total_count : Int32 | Int64
+          @total_count ||= queryset.size
         end
 
         private def validate_number(number)


### PR DESCRIPTION
Adds a `total_count` method that returns the total number of records in the queryset without applying pagination.

This is useful for paginators that need both the total number of pages and the total record count. Instead of recalculating the total size repeatedly, this method centralizes and reuses that logic.

Inspired by [kaminari](https://github.com/kaminari/kaminari/blob/ca4a5dcfce40ede7990ebfe00a12f21e78e910d9/kaminari-activerecord/lib/kaminari/activerecord/active_record_relation_methods.rb#L17)