### PR TITLE
Fix incompatible list in editorconfig

### DIFF
--- a/src/marten/cli/manage/command/new/templates/shared/.editorconfig.ecr
+++ b/src/marten/cli/manage/command/new/templates/shared/.editorconfig.ecr
@@ -6,7 +6,7 @@ end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
 
-[*.cr,*.ecr]
+[*.{cr,ecr}]
 charset = utf-8
 end_of_line = lf
 insert_final_newline = true


### PR DESCRIPTION
At least from the example. Here's proof from a new project:

```cmd
# without change
renich@desktop myproj$ cat .editorconfig 
root = true

[*]
charset = utf-8
end_of_line = lf
insert_final_newline = true
trim_trailing_whitespace = true

[*.cr,*.ecr]
charset = utf-8
end_of_line = lf
insert_final_newline = true
indent_style = space
indent_size = 2
trim_trailing_whitespace = true

[*.md]
trim_trailing_whitespace = false

[Makefile]
indent_style = tab

renich@desktop myproj$ editorconfig $( readlink -f seed.cr )
charset=utf-8
end_of_line=lf
insert_final_newline=true
trim_trailing_whitespace=true

# after change
renich@desktop myproj$ cat .editorconfig 
root = true

[*]
charset = utf-8
end_of_line = lf
insert_final_newline = true
trim_trailing_whitespace = true

[*.{cr,ecr}]
charset = utf-8
end_of_line = lf
insert_final_newline = true
indent_style = space
indent_size = 2
trim_trailing_whitespace = true

[*.md]
trim_trailing_whitespace = false

[Makefile]
indent_style = tab
renich@desktop myproj$ editorconfig $( readlink -f seed.cr )
charset=utf-8
end_of_line=lf
insert_final_newline=true
trim_trailing_whitespace=true
indent_style=space
indent_size=2
tab_width=2
```

As you can see, it recognizes all settings now.

Reference: https://spec.editorconfig.org/#glob-expressions