### PR TITLE
Fix `ManyToManySet#add` if an existing relation has no `id` field

### DIFF
--- a/spec/marten/db/query/many_to_many_set_spec.cr
+++ b/spec/marten/db/query/many_to_many_set_spec.cr
@@ -105,6 +105,42 @@ describe Marten::DB::Query::ManyToManySet do
 
       qset.to_set.should eq(Set{tag_1, tag_2})
     end
+
+    it "adds the given records to the considered object's set of associated objects with a non-id pk" do
+      order = Order.create!
+      product = Product.create!(
+        sku: "ABC-123-XYZ",
+        name: "Widget",
+        price_cents: 19_99
+      )
+
+      order.products.add(product)
+
+      qset = Marten::DB::Query::ManyToManySet(Product).new(order, "products", "order_products", "order", "product")
+      qset.all.to_set.should eq(Set{product})
+    end
+
+    it (
+      "does not add records that are already in the considered"
+      " object's set of associated objects with a non-id pk"
+    ) do
+      order = Order.create!
+      product = Product.create!(
+        sku: "ABC-123-XYZ",
+        name: "Widget",
+        price_cents: 19_99
+      )
+
+      order.products.add(product)
+
+      qset = Marten::DB::Query::ManyToManySet(Product).new(order, "products", "order_products", "order", "product")
+      qset.all.to_set.should eq(Set{product})
+
+      order.products.add(product)
+
+      qset = Marten::DB::Query::ManyToManySet(Product).new(order, "products", "order_products", "order", "product")
+      qset.all.to_set.should eq(Set{product})
+    end
   end
 
   describe "#clear" do

--- a/spec/test_project/models/order.cr
+++ b/spec/test_project/models/order.cr
@@ -1,0 +1,6 @@
+class Order < Marten::Model
+  field :id, :big_int, primary_key: true, auto: true
+  field :products, :many_to_many, to: Product, related: :orders
+
+  with_timestamp_fields
+end

--- a/spec/test_project/models/product.cr
+++ b/spec/test_project/models/product.cr
@@ -1,0 +1,7 @@
+class Product < Marten::Model
+  field :sku, :string, max_size: 20, primary_key: true, unique: true
+  field :name, :string, max_size: 255
+  field :price_cents, :big_int, null: false
+
+  with_timestamp_fields
+end

--- a/src/marten/db/query/many_to_many_set.cr
+++ b/src/marten/db/query/many_to_many_set.cr
@@ -53,7 +53,7 @@ module Marten
 
             # Add each object that was not already in the relationship.
             through_objs_to_add = objs.compact_map do |obj|
-              next if existing_object_ids.includes?(obj.id)
+              next if existing_object_ids.includes?(obj.pk)
               through_obj = m2m_field.as(Field::ManyToMany).through.new
               through_obj.set_field_value(m2m_through_from_field.id, @instance.pk)
               through_obj.set_field_value(m2m_through_to_field.id, obj.pk)


### PR DESCRIPTION
If a related m2m model has no `id` field as pk and it is added to the m2m relation twice following error is raised:

```bash
Error: undefined method 'id' for Country
```