### PR TITLE
Add route field to HTTP::Request

### DIFF
--- a/spec/marten/server/handlers/routing_spec.cr
+++ b/spec/marten/server/handlers/routing_spec.cr
@@ -16,6 +16,8 @@ describe Marten::Server::Handlers::Routing do
 
       handler.call(context)
 
+      context.marten.request.route.not_nil!.rule.name.should eq "dummy"
+      context.marten.request.route.not_nil!.rule.path.should eq "/dummy"
       context.marten.response.not_nil!.content.should eq "It works!"
     end
 
@@ -33,6 +35,8 @@ describe Marten::Server::Handlers::Routing do
 
       handler.call(context)
 
+      context.marten.request.route.not_nil!.rule.name.should eq "dummy_with_id_and_scope"
+      context.marten.request.route.not_nil!.rule.path.should eq "/dummy/<id:int>/and/<scope:slug>"
       context.marten.response.not_nil!.content.should eq "It works!"
     end
 

--- a/src/marten/http/request.cr
+++ b/src/marten/http/request.cr
@@ -13,6 +13,7 @@ module Marten
       @host_and_port : NamedTuple(host: String, port: String)?
       @scheme : String?
       @session : Session::Store::Base?
+      property route : Marten::Routing::Match?
 
       def initialize(@request : ::HTTP::Request)
         # Overrides the request's body IO object so that it's possible to do seek/rewind operations on it if needed.

--- a/src/marten/routing/match.cr
+++ b/src/marten/routing/match.cr
@@ -4,8 +4,9 @@ module Marten
     struct Match
       getter handler
       getter kwargs
+      getter rule
 
-      def initialize(@handler : Marten::Handlers::Base.class, @kwargs = MatchParameters.new)
+      def initialize(@handler : Marten::Handlers::Base.class, @kwargs = MatchParameters.new, @rule = Marten::Routing::Rule::Path.new)
       end
     end
   end

--- a/src/marten/routing/rule/map.cr
+++ b/src/marten/routing/rule/map.cr
@@ -25,7 +25,7 @@ module Marten
 
           return if sub_match.nil?
 
-          Match.new(sub_match.handler, match.parameters.merge(sub_match.kwargs))
+          Match.new(handler: sub_match.handler, kwargs: match.parameters.merge(sub_match.kwargs), rule: sub_match.rule)
         end
 
         protected def reversers : Array(Reverser)

--- a/src/marten/routing/rule/path.cr
+++ b/src/marten/routing/rule/path.cr
@@ -17,7 +17,7 @@ module Marten
           match = @path_info.resolve(path)
           return if match.nil?
 
-          Match.new(@handler, match.parameters)
+          Match.new(handler: @handler, kwargs: match.parameters, rule: self)
         end
 
         protected def reversers : Array(Reverser)

--- a/src/marten/server/handlers/routing.cr
+++ b/src/marten/server/handlers/routing.cr
@@ -22,6 +22,7 @@ module Marten
 
         private def process(context)
           matched = Marten.routes.resolve(context.request.path)
+          context.marten.request.route = matched
 
           debug_mode_info_log("Routed to: #{matched.handler.name}")
 


### PR DESCRIPTION
Allow to get route information from the request object.

It allows to access the route information in Middleware and Handler.

```
request.route.rule.name
request.route.handler.name
request.route.rule.path
```