### PR TITLE
Fix schema array documentation

### DIFF
--- a/docs/docs/schemas/reference/fields.md
+++ b/docs/docs/schemas/reference/fields.md
@@ -23,7 +23,7 @@ For example, the following schema allows validating an array of strings:
 
 ```crystal
 class ColorsSchema < Marten::Schema
-  field :colors, of: :string
+  field :colors, :array, of: :string
 end
 ```
 
@@ -31,7 +31,7 @@ It is possible to specify options that are specific to the chosen array member f
 
 ```crystal
 class ColorsSchema < Marten::Schema
-  field :colors, of: :string, max_size: 10
+  field :colors, :array, of: :string, max_size: 10
 end
 ```
 


### PR DESCRIPTION
I tried the schema array field and it did not work as described in the documentation. Figured it needs the `:array` type specifier, as other fields too.