### PR TITLE
chore: Cover with tests the same scope name for different Models

### DIFF
--- a/spec/marten/db/model/querying_spec.cr
+++ b/spec/marten/db/model/querying_spec.cr
@@ -1355,7 +1355,8 @@ describe Marten::DB::Model::Querying do
       post_1 = Marten::DB::Model::QueryingSpec::Post.create!(
         title: "Post 1",
         content: "Content 1",
-        published: true
+        published: true,
+        published_at: 10.days.from_now,
       )
       post_2 = Marten::DB::Model::QueryingSpec::Post.create!(
         title: "Post 2",
@@ -1365,11 +1366,13 @@ describe Marten::DB::Model::Querying do
       post_3 = Marten::DB::Model::QueryingSpec::Post.create!(
         title: "Post 3",
         content: "Content 3",
-        published: true
+        published: true,
+        published_at: 1.day.ago,
       )
 
       Marten::DB::Model::QueryingSpec::Post.all.to_a.should eq [post_1, post_2, post_3]
       Marten::DB::Model::QueryingSpec::Post.published.to_a.should eq [post_1, post_3]
+      Marten::DB::Model::QueryingSpec::Post.active.to_a.should eq [post_3]
     end
 
     it "allows to define a scope that requires arguments for a model" do

--- a/spec/marten/db/model/querying_spec/models/post.cr
+++ b/spec/marten/db/model/querying_spec/models/post.cr
@@ -12,5 +12,6 @@ module Marten::DB::Model::QueryingSpec
     scope :published { filter(published: true) }
     scope :recent { filter(published_at__gt: 1.year.ago) }
     scope :prefixed { |prefix| filter(title__istartswith: prefix) }
+    scope :active { filter(published: true, published_at__gt: Time.utc) }
   end
 end


### PR DESCRIPTION
I am testing the strange behavior for my code, where the scope is shared between different models.

```crystal
class Raffle < Marten::Model
  db_table :raffles
  with_timestamp_fields

  field :id, :big_int, primary_key: true, auto: true
  field :state, :int, default: 0

  scope :available { filter(state__in: [0, 1]) }
end

class Product < Marten::Model
  db_table :products
  with_timestamp_fields

  field :id, :int, primary_key: true, auto: true
  field :available, :bool, null: false, blank: true, default: false

  scope :available { filter(available: true) }
end

Product.available.filter(id: 1) 
# Exception     
# Marten::DB::Errors::InvalidField: Unable to resolve 'state' as a field. Valid choices are: created_at, updated_at, id, available.
#    lib/marten/src/marten/db/query/set.cr:552:11 in 'filter:state__in'
#    src/models/product.cr:1:1 in 'available'
```


## Tophat

### Tests

After introducing the same scope in the tests for [Post](https://github.com/martenframework/marten/pull/312/files#diff-f9dd5eb32c7727d525787af849298d6ce300fa1721ff82472fe05de691a43df4R15) model, to have the same scope name as for [Tag](https://github.com/martenframework/marten/blob/1e5b4f99bebc389a2b0d66011a1141435025abb8/spec/marten/db/model/querying_spec/models/tag.cr#L7), I see next:

```
Failures:

  1) Marten::DB::Model::Querying ::scope allows to define a scope for a model

       Unable to resolve 'is_active' as a field. Valid choices are: author_id, tags, id, title, content, published, published_at, created_at. (Marten::DB::Errors::InvalidField)
         from /home/runner/work/_temp/crystal-1.14.0-true-undefined/share/crystal/src/enumerable.cr:987:7 in 'raise_invalid_field_error_with_valid_choices'
         from src/marten/db/query/sql/query.cr:1030:19 in 'raise_invalid_field_error_with_valid_choices:allow_many'
```