### PR TITLE
fix(media): support URL‑encoded filenames in development file lookup

### DIFF
--- a/spec/marten/handlers/defaults/development/serve_media_file_spec.cr
+++ b/spec/marten/handlers/defaults/development/serve_media_file_spec.cr
@@ -26,6 +26,30 @@ describe Marten::Handlers::Defaults::Development::ServeMediaFile do
       response.content.should eq File.read(file_path)
     end
 
+    it "returns the content of a specific media file with spaces in its name" do
+      dir_path = File.join(Marten.settings.media_files.root, "test")
+      file_path = File.join(dir_path, "test with spaces.txt")
+
+      FileUtils.mkdir_p(dir_path)
+      File.write(file_path, "Hello World")
+
+      request = Marten::HTTP::Request.new(
+        ::HTTP::Request.new(
+          method: "GET",
+          resource: "",
+          headers: HTTP::Headers{"Host" => "example.com"}
+        )
+      )
+      params = Marten::Routing::MatchParameters{"path" => "test/test%20with%20spaces.txt"}
+      handler = Marten::Handlers::Defaults::Development::ServeMediaFile.new(request, params)
+
+      response = handler.dispatch
+
+      response.status.should eq 200
+      response.content_type.should eq MIME.from_filename(file_path)
+      response.content.should eq File.read(file_path)
+    end
+
     it "returns a 404 response if the media file cannot be found" do
       request = Marten::HTTP::Request.new(
         ::HTTP::Request.new(

--- a/src/marten/handlers/defaults/development/serve_media_file.cr
+++ b/src/marten/handlers/defaults/development/serve_media_file.cr
@@ -4,7 +4,7 @@ module Marten
       module Development
         class ServeMediaFile < Base
           def get
-            filepath = params["path"].as(String)
+            filepath = URI.decode(params["path"].as(String))
             return head 404 if !Marten.media_files_storage.exists?(filepath)
 
             content_type = begin


### PR DESCRIPTION
Previously, files with percent‑encoded characters (e.g. "%20") in media paths were not found. Now decode the requested path before lookup, ensuring media assets with spaces or other URL‑encoded names are served.