### PR TITLE
Time predicates

### DIFF
--- a/docs/docs/models-and-databases/reference/query-set.md
+++ b/docs/docs/models-and-databases/reference/query-set.md
@@ -1049,3 +1049,40 @@ Allows filtering records based on field values that start with a specific substr
 ```crystal
 Article.all.filter(title__startswith: "Top")
 ```
+
+## Time predicates
+
+Marten also supports time-related predicates that let you filter on specific parts of `date` and `date_time` fields.
+
+The following time predicates are available:
+
+| Predicate | Description | Supported field types | Example |
+|-----------|-------------|-----------------------|---------|
+| `year` | Filters by year | `date`, `date_time` | `published_at__year: 2025` |
+| `month` | Filters by month (`1..12`) | `date`, `date_time` | `created_at__month: 12` |
+| `day` | Filters by day of month (`1..31`) | `date`, `date_time` | `updated_at__day: 15` |
+| `hour` | Filters by hour (`0..23`) | `date_time` | `created_at__hour: 14` |
+| `minute` | Filters by minute (`0..59`) | `date_time` | `logged_at__minute: 30` |
+| `second` | Filters by second (`0..59`) | `date_time` | `timestamp__second: 45` |
+
+```crystal
+# Basic usage
+Article.filter(published_at__year: 2025)
+Article.filter(created_at__month: 12)
+
+# Through relations
+Post.filter(author__created_at__year: 2024)
+```
+
+Time predicates also support comparator chaining with `exact`, `gt`, `gte`, `lt`, `lte`, `in`, and `isnull`:
+
+```crystal
+Article.filter(created_at__year__exact: 2022)
+Article.filter(created_at__year__gte: 2022)
+Article.filter(created_at__hour__lt: 12)
+Article.filter(created_at__month__in: [11, 12])
+Article.filter(created_at__year__isnull: false)
+```
+
+Accepted values for scalar comparisons are integers, numeric strings (for example `"2025"`), or `Time` instances.
+For `in`, pass arrays containing these value types. For `isnull`, pass a boolean.

--- a/spec/marten/db/connection/mysql_spec.cr
+++ b/spec/marten/db/connection/mysql_spec.cr
@@ -35,6 +35,16 @@ for_mysql do
         conn.left_operand_for("table.column", "contains").should eq "table.column"
         conn.left_operand_for("table.column", "istartswith").should eq "table.column"
       end
+
+      it "returns the expected operand for a month predicate" do
+        conn = Marten::DB::Connection.default
+        conn.left_operand_for("table.column", "month").should eq "MONTH(table.column)"
+      end
+
+      it "returns the expected operand for an hour predicate" do
+        conn = Marten::DB::Connection.default
+        conn.left_operand_for("table.column", "hour").should eq "HOUR(table.column)"
+      end
     end
 
     describe "#limit_value" do

--- a/spec/marten/db/connection/postgresq_spec.cr
+++ b/spec/marten/db/connection/postgresq_spec.cr
@@ -67,6 +67,16 @@ for_postgresql do
         conn.left_operand_for("table.column", "contains").should eq "table.column"
         conn.left_operand_for("table.column", "exact").should eq "table.column"
       end
+
+      it "returns the expected operand for a year predicate" do
+        conn = Marten::DB::Connection.default
+        conn.left_operand_for("table.column", "year").should eq "EXTRACT(YEAR FROM table.column)"
+      end
+
+      it "returns the expected operand for a minute predicate" do
+        conn = Marten::DB::Connection.default
+        conn.left_operand_for("table.column", "minute").should eq "EXTRACT(MINUTE FROM table.column)"
+      end
     end
 
     describe "#max_name_size" do

--- a/spec/marten/db/connection/sqlite_spec.cr
+++ b/spec/marten/db/connection/sqlite_spec.cr
@@ -45,6 +45,16 @@ for_sqlite do
         conn.left_operand_for("table.column", "contains").should eq "table.column"
         conn.left_operand_for("table.column", "istartswith").should eq "table.column"
       end
+
+      it "returns the expected operand for a year predicate" do
+        conn = Marten::DB::Connection.default
+        conn.left_operand_for("table.column", "year").should eq "CAST(STRFTIME('%Y', table.column) AS INTEGER)"
+      end
+
+      it "returns the expected operand for a second predicate" do
+        conn = Marten::DB::Connection.default
+        conn.left_operand_for("table.column", "second").should eq "CAST(STRFTIME('%S', table.column) AS INTEGER)"
+      end
     end
 
     describe "#limit_value" do

--- a/spec/marten/db/model/querying_spec.cr
+++ b/spec/marten/db/model/querying_spec.cr
@@ -373,6 +373,55 @@ describe Marten::DB::Model::Querying do
     end
   end
 
+  describe "::filter with time-part predicates" do
+    with_installed_apps Marten::DB::Model::QueryingSpec::App
+
+    it "allows filtering date and date_time fields using time-part predicates" do
+      record_1 = Marten::DB::Model::QueryingSpec::TemporalRecord.create!(
+        label: "Record 1",
+        event_date: Time.utc(2023, 12, 1),
+        event_at: Time.utc(2023, 12, 1, 9, 10, 11),
+      )
+      record_2 = Marten::DB::Model::QueryingSpec::TemporalRecord.create!(
+        label: "Record 2",
+        event_date: Time.utc(2024, 12, 28),
+        event_at: Time.utc(2024, 12, 28, 23, 55, 45),
+      )
+      record_3 = Marten::DB::Model::QueryingSpec::TemporalRecord.create!(
+        label: "Record 3",
+        event_date: Time.utc(2024, 11, 12),
+        event_at: Time.utc(2024, 11, 12, 7, 15, 5),
+      )
+
+      Marten::DB::Model::QueryingSpec::TemporalRecord.filter(event_date__year: 2024).order(:id).to_a.should eq(
+        [record_2, record_3]
+      )
+      Marten::DB::Model::QueryingSpec::TemporalRecord.filter(event_at__month: "12").order(:id).to_a.should eq(
+        [record_1, record_2]
+      )
+      Marten::DB::Model::QueryingSpec::TemporalRecord.filter(event_at__year__gte: Time.utc(2024, 1, 1))
+        .order(:id)
+        .to_a
+        .should eq([record_2, record_3])
+      Marten::DB::Model::QueryingSpec::TemporalRecord.filter(event_at__year__exact: 2024).order(:id).to_a.should eq(
+        [record_2, record_3]
+      )
+      Marten::DB::Model::QueryingSpec::TemporalRecord.filter(
+        event_date__month__in: ([Time.utc(2024, 11, 1), "12"] of Marten::DB::Field::Any)
+      )
+        .order(:id)
+        .to_a
+        .should eq([record_1, record_2, record_3])
+      Marten::DB::Model::QueryingSpec::TemporalRecord.filter(event_at__year__isnull: false)
+        .order(:id)
+        .to_a
+        .should eq([record_1, record_2, record_3])
+      Marten::DB::Model::QueryingSpec::TemporalRecord.filter(event_at__year__isnull: true).to_a.should eq(
+        [] of Marten::DB::Model::QueryingSpec::TemporalRecord
+      )
+    end
+  end
+
   describe "::first" do
     before_each do
       TestUser.create!(username: "jd1", email: "jd1@example.com", first_name: "John", last_name: "Doe")

--- a/spec/marten/db/model/querying_spec/models/temporal_record.cr
+++ b/spec/marten/db/model/querying_spec/models/temporal_record.cr
@@ -1,0 +1,8 @@
+module Marten::DB::Model::QueryingSpec
+  class TemporalRecord < Marten::Model
+    field :id, :big_int, primary_key: true, auto: true
+    field :label, :string, max_size: 100
+    field :event_date, :date
+    field :event_at, :date_time
+  end
+end

--- a/spec/marten/db/query/set_spec.cr
+++ b/spec/marten/db/query/set_spec.cr
@@ -1386,6 +1386,105 @@ describe Marten::DB::Query::Set do
       qset.to_a.sort_by(&.pk!.to_s).should eq [tag_2, tag_3].sort_by(&.pk!.to_s)
     end
 
+    it "allows filtering records with time-part predicates" do
+      record_1 = Marten::DB::Query::SetSpec::TemporalRecord.create!(
+        label: "Record 1",
+        event_date: Time.utc(2023, 12, 1),
+        event_at: Time.utc(2023, 12, 1, 9, 10, 11),
+      )
+      record_2 = Marten::DB::Query::SetSpec::TemporalRecord.create!(
+        label: "Record 2",
+        event_date: Time.utc(2024, 12, 28),
+        event_at: Time.utc(2024, 12, 28, 23, 55, 45),
+      )
+      record_3 = Marten::DB::Query::SetSpec::TemporalRecord.create!(
+        label: "Record 3",
+        event_date: Time.utc(2024, 11, 12),
+        event_at: Time.utc(2024, 11, 12, 7, 15, 5),
+      )
+
+      qset = Marten::DB::Query::Set(Marten::DB::Query::SetSpec::TemporalRecord).new.order(:id)
+
+      qset.filter(event_date__year: 2024).to_a.should eq [record_2, record_3]
+      qset.filter(event_date__month: 12).to_a.should eq [record_1, record_2]
+      qset.filter(event_date__day: 12).to_a.should eq [record_3]
+      qset.filter(event_at__hour: 23).to_a.should eq [record_2]
+      qset.filter(event_at__minute: 55).to_a.should eq [record_2]
+      qset.filter(event_at__second: 5).to_a.should eq [record_3]
+    end
+
+    it "allows chaining comparison predicates with time-part predicates" do
+      record_1 = Marten::DB::Query::SetSpec::TemporalRecord.create!(
+        label: "Record 1",
+        event_date: Time.utc(2023, 6, 1),
+        event_at: Time.utc(2023, 6, 1, 11, 0, 0),
+      )
+      record_2 = Marten::DB::Query::SetSpec::TemporalRecord.create!(
+        label: "Record 2",
+        event_date: Time.utc(2024, 12, 28),
+        event_at: Time.utc(2024, 12, 28, 23, 55, 45),
+      )
+      record_3 = Marten::DB::Query::SetSpec::TemporalRecord.create!(
+        label: "Record 3",
+        event_date: Time.utc(2024, 2, 12),
+        event_at: Time.utc(2024, 2, 12, 7, 15, 5),
+      )
+
+      qset = Marten::DB::Query::Set(Marten::DB::Query::SetSpec::TemporalRecord).new.order(:id)
+
+      qset.filter(event_at__year__gte: 2024).to_a.should eq [record_2, record_3]
+      qset.filter(event_at__year__lt: 2024).to_a.should eq [record_1]
+      qset.filter(event_at__hour__gt: 10).to_a.should eq [record_1, record_2]
+      qset.filter(event_date__month__lte: 6).to_a.should eq [record_1, record_3]
+      qset.filter(event_at__month__in: ([Time.utc(2024, 6, 1), "12"] of Marten::DB::Field::Any)).to_a.should eq(
+        [record_1, record_2]
+      )
+      qset.filter(event_at__year__isnull: false).to_a.should eq [record_1, record_2, record_3]
+      qset.filter(event_at__year__isnull: true).to_a.should eq([] of Marten::DB::Query::SetSpec::TemporalRecord)
+    end
+
+    it "coerces Time and numeric strings when filtering time-part predicates" do
+      record_1 = Marten::DB::Query::SetSpec::TemporalRecord.create!(
+        label: "Record 1",
+        event_date: Time.utc(2023, 12, 1),
+        event_at: Time.utc(2023, 12, 1, 9, 10, 11),
+      )
+      record_2 = Marten::DB::Query::SetSpec::TemporalRecord.create!(
+        label: "Record 2",
+        event_date: Time.utc(2024, 12, 28),
+        event_at: Time.utc(2024, 12, 28, 23, 55, 45),
+      )
+      record_3 = Marten::DB::Query::SetSpec::TemporalRecord.create!(
+        label: "Record 3",
+        event_date: Time.utc(2024, 11, 12),
+        event_at: Time.utc(2024, 11, 12, 7, 15, 5),
+      )
+
+      qset = Marten::DB::Query::Set(Marten::DB::Query::SetSpec::TemporalRecord).new.order(:id)
+
+      qset.filter(event_at__year: Time.utc(2024, 5, 1)).to_a.should eq [record_2, record_3]
+      qset.filter(event_at__month: "12").to_a.should eq [record_1, record_2]
+    end
+
+    it "raises for invalid time-part filters" do
+      Marten::DB::Query::SetSpec::TemporalRecord.create!(
+        label: "Record",
+        event_date: Time.utc(2024, 12, 28),
+        event_at: Time.utc(2024, 12, 28, 23, 55, 45),
+      )
+
+      qset = Marten::DB::Query::Set(Marten::DB::Query::SetSpec::TemporalRecord).new
+
+      expect_raises(Marten::DB::Errors::InvalidField) { qset.filter(label__year: 2024).to_a }
+      expect_raises(Marten::DB::Errors::InvalidField) { qset.filter(event_date__hour: 10).to_a }
+      expect_raises(Marten::DB::Errors::UnmetQuerySetCondition) { qset.filter(event_at__month: 13).to_a }
+      expect_raises(Marten::DB::Errors::UnmetQuerySetCondition) { qset.filter(event_at__hour: 24).to_a }
+      expect_raises(Marten::DB::Errors::UnmetQuerySetCondition) { qset.filter(event_at__second: "foo").to_a }
+      expect_raises(Marten::DB::Errors::UnmetQuerySetCondition) { qset.filter(event_at__year__in: "2024").to_a }
+      expect_raises(Marten::DB::Errors::UnmetQuerySetCondition) { qset.filter(event_at__year__isnull: "false").to_a }
+      expect_raises(Marten::DB::Errors::InvalidField) { qset.filter(event_at__year__contains: 2024).to_a }
+    end
+
     it "filters records using a raw SQL equality condition", tags: "raw" do
       Tag.create!(name: "ruby", is_active: true)
       tag_2 = Tag.create!(name: "crystal", is_active: true)

--- a/spec/marten/db/query/set_spec/models/temporal_record.cr
+++ b/spec/marten/db/query/set_spec/models/temporal_record.cr
@@ -1,0 +1,8 @@
+module Marten::DB::Query::SetSpec
+  class TemporalRecord < Marten::Model
+    field :id, :big_int, primary_key: true, auto: true
+    field :label, :string, max_size: 100
+    field :event_date, :date
+    field :event_at, :date_time
+  end
+end

--- a/spec/marten/db/query/sql/predicate/day_spec.cr
+++ b/spec/marten/db/query/sql/predicate/day_spec.cr
@@ -1,0 +1,81 @@
+require "./spec_helper"
+
+describe Marten::DB::Query::SQL::Predicate::Day do
+  describe "#to_sql" do
+    it "returns the expected SQL statement" do
+      predicate = Marten::DB::Query::SQL::Predicate::Day.new(TestUser.get_field("created_at"), 5, "table")
+
+      for_mysql do
+        predicate.to_sql(Marten::DB::Connection.default).should eq(
+          {"DAY(table.created_at) = %s", [5_i64]}
+        )
+      end
+
+      for_postgresql do
+        predicate.to_sql(Marten::DB::Connection.default).should eq(
+          {"EXTRACT(DAY FROM table.created_at) = %s", [5_i64]}
+        )
+      end
+
+      for_sqlite do
+        predicate.to_sql(Marten::DB::Connection.default).should eq(
+          {"CAST(STRFTIME('%d', table.created_at) AS INTEGER) = %s", [5_i64]}
+        )
+      end
+    end
+
+    it "returns the expected SQL statement for an in comparison predicate" do
+      predicate = Marten::DB::Query::SQL::Predicate::Day.new(
+        TestUser.get_field("created_at"),
+        ([Time.utc(2024, 1, 31), "5"] of Marten::DB::Field::Any),
+        "table",
+        comparison_predicate: "in",
+      )
+
+      for_mysql do
+        predicate.to_sql(Marten::DB::Connection.default).should eq(
+          {"DAY(table.created_at) IN ( %s , %s )", [31_i64, 5_i64]}
+        )
+      end
+
+      for_postgresql do
+        predicate.to_sql(Marten::DB::Connection.default).should eq(
+          {"EXTRACT(DAY FROM table.created_at) IN ( %s , %s )", [31_i64, 5_i64]}
+        )
+      end
+
+      for_sqlite do
+        predicate.to_sql(Marten::DB::Connection.default).should eq(
+          {"CAST(STRFTIME('%d', table.created_at) AS INTEGER) IN ( %s , %s )", [31_i64, 5_i64]}
+        )
+      end
+    end
+
+    it "returns the expected SQL statement for an isnull comparison predicate" do
+      predicate = Marten::DB::Query::SQL::Predicate::Day.new(
+        TestUser.get_field("created_at"),
+        true,
+        "table",
+        comparison_predicate: "isnull",
+      )
+
+      for_mysql do
+        predicate.to_sql(Marten::DB::Connection.default).should eq(
+          {"DAY(table.created_at) IS NULL", [] of ::DB::Any}
+        )
+      end
+
+      for_postgresql do
+        predicate.to_sql(Marten::DB::Connection.default).should eq(
+          {"EXTRACT(DAY FROM table.created_at) IS NULL", [] of ::DB::Any}
+        )
+      end
+
+      for_sqlite do
+        predicate.to_sql(Marten::DB::Connection.default).should eq(
+          {"CAST(STRFTIME('%d', table.created_at) AS INTEGER) IS NULL", [] of ::DB::Any}
+        )
+      end
+    end
+  end
+end

--- a/spec/marten/db/query/sql/predicate/hour_spec.cr
+++ b/spec/marten/db/query/sql/predicate/hour_spec.cr
@@ -1,0 +1,93 @@
+require "./spec_helper"
+
+describe Marten::DB::Query::SQL::Predicate::Hour do
+  describe "#to_sql" do
+    it "returns the expected SQL statement" do
+      predicate = Marten::DB::Query::SQL::Predicate::Hour.new(TestUser.get_field("created_at"), 5, "table")
+
+      for_mysql do
+        predicate.to_sql(Marten::DB::Connection.default).should eq(
+          {"HOUR(table.created_at) = %s", [5_i64]}
+        )
+      end
+
+      for_postgresql do
+        predicate.to_sql(Marten::DB::Connection.default).should eq(
+          {"EXTRACT(HOUR FROM table.created_at) = %s", [5_i64]}
+        )
+      end
+
+      for_sqlite do
+        predicate.to_sql(Marten::DB::Connection.default).should eq(
+          {"CAST(STRFTIME('%H', table.created_at) AS INTEGER) = %s", [5_i64]}
+        )
+      end
+    end
+
+    it "raises if the field is not a date_time field" do
+      predicate = Marten::DB::Query::SQL::Predicate::Hour.new(
+        Post.get_field("title"),
+        5,
+        "table"
+      )
+
+      expect_raises(Marten::DB::Errors::InvalidField, "'hour' can only be used with date_time fields") do
+        predicate.to_sql(Marten::DB::Connection.default)
+      end
+    end
+
+    it "returns the expected SQL statement for an in comparison predicate" do
+      predicate = Marten::DB::Query::SQL::Predicate::Hour.new(
+        TestUser.get_field("created_at"),
+        ([Time.utc(2024, 1, 1, 23, 0, 0), "5"] of Marten::DB::Field::Any),
+        "table",
+        comparison_predicate: "in",
+      )
+
+      for_mysql do
+        predicate.to_sql(Marten::DB::Connection.default).should eq(
+          {"HOUR(table.created_at) IN ( %s , %s )", [23_i64, 5_i64]}
+        )
+      end
+
+      for_postgresql do
+        predicate.to_sql(Marten::DB::Connection.default).should eq(
+          {"EXTRACT(HOUR FROM table.created_at) IN ( %s , %s )", [23_i64, 5_i64]}
+        )
+      end
+
+      for_sqlite do
+        predicate.to_sql(Marten::DB::Connection.default).should eq(
+          {"CAST(STRFTIME('%H', table.created_at) AS INTEGER) IN ( %s , %s )", [23_i64, 5_i64]}
+        )
+      end
+    end
+
+    it "returns the expected SQL statement for an isnull comparison predicate" do
+      predicate = Marten::DB::Query::SQL::Predicate::Hour.new(
+        TestUser.get_field("created_at"),
+        false,
+        "table",
+        comparison_predicate: "isnull",
+      )
+
+      for_mysql do
+        predicate.to_sql(Marten::DB::Connection.default).should eq(
+          {"HOUR(table.created_at) IS NOT NULL", [] of ::DB::Any}
+        )
+      end
+
+      for_postgresql do
+        predicate.to_sql(Marten::DB::Connection.default).should eq(
+          {"EXTRACT(HOUR FROM table.created_at) IS NOT NULL", [] of ::DB::Any}
+        )
+      end
+
+      for_sqlite do
+        predicate.to_sql(Marten::DB::Connection.default).should eq(
+          {"CAST(STRFTIME('%H', table.created_at) AS INTEGER) IS NOT NULL", [] of ::DB::Any}
+        )
+      end
+    end
+  end
+end

--- a/spec/marten/db/query/sql/predicate/minute_spec.cr
+++ b/spec/marten/db/query/sql/predicate/minute_spec.cr
@@ -1,0 +1,81 @@
+require "./spec_helper"
+
+describe Marten::DB::Query::SQL::Predicate::Minute do
+  describe "#to_sql" do
+    it "returns the expected SQL statement" do
+      predicate = Marten::DB::Query::SQL::Predicate::Minute.new(TestUser.get_field("created_at"), 5, "table")
+
+      for_mysql do
+        predicate.to_sql(Marten::DB::Connection.default).should eq(
+          {"MINUTE(table.created_at) = %s", [5_i64]}
+        )
+      end
+
+      for_postgresql do
+        predicate.to_sql(Marten::DB::Connection.default).should eq(
+          {"EXTRACT(MINUTE FROM table.created_at) = %s", [5_i64]}
+        )
+      end
+
+      for_sqlite do
+        predicate.to_sql(Marten::DB::Connection.default).should eq(
+          {"CAST(STRFTIME('%M', table.created_at) AS INTEGER) = %s", [5_i64]}
+        )
+      end
+    end
+
+    it "returns the expected SQL statement for an in comparison predicate" do
+      predicate = Marten::DB::Query::SQL::Predicate::Minute.new(
+        TestUser.get_field("created_at"),
+        ([Time.utc(2024, 1, 1, 0, 59, 0), "5"] of Marten::DB::Field::Any),
+        "table",
+        comparison_predicate: "in",
+      )
+
+      for_mysql do
+        predicate.to_sql(Marten::DB::Connection.default).should eq(
+          {"MINUTE(table.created_at) IN ( %s , %s )", [59_i64, 5_i64]}
+        )
+      end
+
+      for_postgresql do
+        predicate.to_sql(Marten::DB::Connection.default).should eq(
+          {"EXTRACT(MINUTE FROM table.created_at) IN ( %s , %s )", [59_i64, 5_i64]}
+        )
+      end
+
+      for_sqlite do
+        predicate.to_sql(Marten::DB::Connection.default).should eq(
+          {"CAST(STRFTIME('%M', table.created_at) AS INTEGER) IN ( %s , %s )", [59_i64, 5_i64]}
+        )
+      end
+    end
+
+    it "returns the expected SQL statement for an isnull comparison predicate" do
+      predicate = Marten::DB::Query::SQL::Predicate::Minute.new(
+        TestUser.get_field("created_at"),
+        true,
+        "table",
+        comparison_predicate: "isnull",
+      )
+
+      for_mysql do
+        predicate.to_sql(Marten::DB::Connection.default).should eq(
+          {"MINUTE(table.created_at) IS NULL", [] of ::DB::Any}
+        )
+      end
+
+      for_postgresql do
+        predicate.to_sql(Marten::DB::Connection.default).should eq(
+          {"EXTRACT(MINUTE FROM table.created_at) IS NULL", [] of ::DB::Any}
+        )
+      end
+
+      for_sqlite do
+        predicate.to_sql(Marten::DB::Connection.default).should eq(
+          {"CAST(STRFTIME('%M', table.created_at) AS INTEGER) IS NULL", [] of ::DB::Any}
+        )
+      end
+    end
+  end
+end

--- a/spec/marten/db/query/sql/predicate/month_spec.cr
+++ b/spec/marten/db/query/sql/predicate/month_spec.cr
@@ -1,0 +1,102 @@
+require "./spec_helper"
+
+describe Marten::DB::Query::SQL::Predicate::Month do
+  describe "#to_sql" do
+    it "returns the expected SQL statement" do
+      predicate = Marten::DB::Query::SQL::Predicate::Month.new(TestUser.get_field("created_at"), 5, "table")
+
+      for_mysql do
+        predicate.to_sql(Marten::DB::Connection.default).should eq(
+          {"MONTH(table.created_at) = %s", [5_i64]}
+        )
+      end
+
+      for_postgresql do
+        predicate.to_sql(Marten::DB::Connection.default).should eq(
+          {"EXTRACT(MONTH FROM table.created_at) = %s", [5_i64]}
+        )
+      end
+
+      for_sqlite do
+        predicate.to_sql(Marten::DB::Connection.default).should eq(
+          {"CAST(STRFTIME('%m', table.created_at) AS INTEGER) = %s", [5_i64]}
+        )
+      end
+    end
+
+    it "raises if the value is outside the expected range" do
+      predicate = Marten::DB::Query::SQL::Predicate::Month.new(TestUser.get_field("created_at"), 13, "table")
+
+      expect_raises(Marten::DB::Errors::UnmetQuerySetCondition, "'month' expects an integer between 1 and 12") do
+        predicate.to_sql(Marten::DB::Connection.default)
+      end
+    end
+
+    it "returns the expected SQL statement for an in comparison predicate" do
+      predicate = Marten::DB::Query::SQL::Predicate::Month.new(
+        TestUser.get_field("created_at"),
+        ([Time.utc(2024, 12, 1), "5"] of Marten::DB::Field::Any),
+        "table",
+        comparison_predicate: "in",
+      )
+
+      for_mysql do
+        predicate.to_sql(Marten::DB::Connection.default).should eq(
+          {"MONTH(table.created_at) IN ( %s , %s )", [12_i64, 5_i64]}
+        )
+      end
+
+      for_postgresql do
+        predicate.to_sql(Marten::DB::Connection.default).should eq(
+          {"EXTRACT(MONTH FROM table.created_at) IN ( %s , %s )", [12_i64, 5_i64]}
+        )
+      end
+
+      for_sqlite do
+        predicate.to_sql(Marten::DB::Connection.default).should eq(
+          {"CAST(STRFTIME('%m', table.created_at) AS INTEGER) IN ( %s , %s )", [12_i64, 5_i64]}
+        )
+      end
+    end
+
+    it "returns the expected SQL statement for an isnull comparison predicate" do
+      predicate = Marten::DB::Query::SQL::Predicate::Month.new(
+        TestUser.get_field("created_at"),
+        false,
+        "table",
+        comparison_predicate: "isnull",
+      )
+
+      for_mysql do
+        predicate.to_sql(Marten::DB::Connection.default).should eq(
+          {"MONTH(table.created_at) IS NOT NULL", [] of ::DB::Any}
+        )
+      end
+
+      for_postgresql do
+        predicate.to_sql(Marten::DB::Connection.default).should eq(
+          {"EXTRACT(MONTH FROM table.created_at) IS NOT NULL", [] of ::DB::Any}
+        )
+      end
+
+      for_sqlite do
+        predicate.to_sql(Marten::DB::Connection.default).should eq(
+          {"CAST(STRFTIME('%m', table.created_at) AS INTEGER) IS NOT NULL", [] of ::DB::Any}
+        )
+      end
+    end
+
+    it "raises if one of the in values is outside the expected range" do
+      predicate = Marten::DB::Query::SQL::Predicate::Month.new(
+        TestUser.get_field("created_at"),
+        [1, 13] of Marten::DB::Field::Any,
+        "table",
+        comparison_predicate: "in",
+      )
+
+      expect_raises(Marten::DB::Errors::UnmetQuerySetCondition, "'month' expects an integer between 1 and 12") do
+        predicate.to_sql(Marten::DB::Connection.default)
+      end
+    end
+  end
+end

--- a/spec/marten/db/query/sql/predicate/second_spec.cr
+++ b/spec/marten/db/query/sql/predicate/second_spec.cr
@@ -1,0 +1,81 @@
+require "./spec_helper"
+
+describe Marten::DB::Query::SQL::Predicate::Second do
+  describe "#to_sql" do
+    it "returns the expected SQL statement" do
+      predicate = Marten::DB::Query::SQL::Predicate::Second.new(TestUser.get_field("created_at"), 5, "table")
+
+      for_mysql do
+        predicate.to_sql(Marten::DB::Connection.default).should eq(
+          {"SECOND(table.created_at) = %s", [5_i64]}
+        )
+      end
+
+      for_postgresql do
+        predicate.to_sql(Marten::DB::Connection.default).should eq(
+          {"EXTRACT(SECOND FROM table.created_at) = %s", [5_i64]}
+        )
+      end
+
+      for_sqlite do
+        predicate.to_sql(Marten::DB::Connection.default).should eq(
+          {"CAST(STRFTIME('%S', table.created_at) AS INTEGER) = %s", [5_i64]}
+        )
+      end
+    end
+
+    it "returns the expected SQL statement for an in comparison predicate" do
+      predicate = Marten::DB::Query::SQL::Predicate::Second.new(
+        TestUser.get_field("created_at"),
+        ([Time.utc(2024, 1, 1, 0, 0, 58), "5"] of Marten::DB::Field::Any),
+        "table",
+        comparison_predicate: "in",
+      )
+
+      for_mysql do
+        predicate.to_sql(Marten::DB::Connection.default).should eq(
+          {"SECOND(table.created_at) IN ( %s , %s )", [58_i64, 5_i64]}
+        )
+      end
+
+      for_postgresql do
+        predicate.to_sql(Marten::DB::Connection.default).should eq(
+          {"EXTRACT(SECOND FROM table.created_at) IN ( %s , %s )", [58_i64, 5_i64]}
+        )
+      end
+
+      for_sqlite do
+        predicate.to_sql(Marten::DB::Connection.default).should eq(
+          {"CAST(STRFTIME('%S', table.created_at) AS INTEGER) IN ( %s , %s )", [58_i64, 5_i64]}
+        )
+      end
+    end
+
+    it "returns the expected SQL statement for an isnull comparison predicate" do
+      predicate = Marten::DB::Query::SQL::Predicate::Second.new(
+        TestUser.get_field("created_at"),
+        false,
+        "table",
+        comparison_predicate: "isnull",
+      )
+
+      for_mysql do
+        predicate.to_sql(Marten::DB::Connection.default).should eq(
+          {"SECOND(table.created_at) IS NOT NULL", [] of ::DB::Any}
+        )
+      end
+
+      for_postgresql do
+        predicate.to_sql(Marten::DB::Connection.default).should eq(
+          {"EXTRACT(SECOND FROM table.created_at) IS NOT NULL", [] of ::DB::Any}
+        )
+      end
+
+      for_sqlite do
+        predicate.to_sql(Marten::DB::Connection.default).should eq(
+          {"CAST(STRFTIME('%S', table.created_at) AS INTEGER) IS NOT NULL", [] of ::DB::Any}
+        )
+      end
+    end
+  end
+end

--- a/spec/marten/db/query/sql/predicate/second_spec.cr
+++ b/spec/marten/db/query/sql/predicate/second_spec.cr
@@ -13,7 +13,7 @@ describe Marten::DB::Query::SQL::Predicate::Second do
 
       for_postgresql do
         predicate.to_sql(Marten::DB::Connection.default).should eq(
-          {"EXTRACT(SECOND FROM table.created_at) = %s", [5_i64]}
+          {"FLOOR(EXTRACT(SECOND FROM table.created_at)) = %s", [5_i64]}
         )
       end
 
@@ -40,7 +40,7 @@ describe Marten::DB::Query::SQL::Predicate::Second do
 
       for_postgresql do
         predicate.to_sql(Marten::DB::Connection.default).should eq(
-          {"EXTRACT(SECOND FROM table.created_at) IN ( %s , %s )", [58_i64, 5_i64]}
+          {"FLOOR(EXTRACT(SECOND FROM table.created_at)) IN ( %s , %s )", [58_i64, 5_i64]}
         )
       end
 
@@ -67,7 +67,7 @@ describe Marten::DB::Query::SQL::Predicate::Second do
 
       for_postgresql do
         predicate.to_sql(Marten::DB::Connection.default).should eq(
-          {"EXTRACT(SECOND FROM table.created_at) IS NOT NULL", [] of ::DB::Any}
+          {"FLOOR(EXTRACT(SECOND FROM table.created_at)) IS NOT NULL", [] of ::DB::Any}
         )
       end
 

--- a/spec/marten/db/query/sql/predicate/year_spec.cr
+++ b/spec/marten/db/query/sql/predicate/year_spec.cr
@@ -1,0 +1,121 @@
+require "./spec_helper"
+
+describe Marten::DB::Query::SQL::Predicate::Year do
+  describe "#to_sql" do
+    it "returns the expected SQL statement" do
+      predicate = Marten::DB::Query::SQL::Predicate::Year.new(TestUser.get_field("created_at"), "2025", "table")
+
+      for_mysql do
+        predicate.to_sql(Marten::DB::Connection.default).should eq(
+          {"YEAR(table.created_at) = %s", [2025_i64]}
+        )
+      end
+
+      for_postgresql do
+        predicate.to_sql(Marten::DB::Connection.default).should eq(
+          {"EXTRACT(YEAR FROM table.created_at) = %s", [2025_i64]}
+        )
+      end
+
+      for_sqlite do
+        predicate.to_sql(Marten::DB::Connection.default).should eq(
+          {"CAST(STRFTIME('%Y', table.created_at) AS INTEGER) = %s", [2025_i64]}
+        )
+      end
+    end
+
+    it "returns the expected SQL statement with a comparison predicate" do
+      predicate = Marten::DB::Query::SQL::Predicate::Year.new(
+        TestUser.get_field("created_at"),
+        2025,
+        "table",
+        comparison_predicate: "gte",
+      )
+
+      for_mysql do
+        predicate.to_sql(Marten::DB::Connection.default).should eq(
+          {"YEAR(table.created_at) >= %s", [2025_i64]}
+        )
+      end
+
+      for_postgresql do
+        predicate.to_sql(Marten::DB::Connection.default).should eq(
+          {"EXTRACT(YEAR FROM table.created_at) >= %s", [2025_i64]}
+        )
+      end
+
+      for_sqlite do
+        predicate.to_sql(Marten::DB::Connection.default).should eq(
+          {"CAST(STRFTIME('%Y', table.created_at) AS INTEGER) >= %s", [2025_i64]}
+        )
+      end
+    end
+
+    it "returns the expected SQL statement for an in comparison predicate" do
+      predicate = Marten::DB::Query::SQL::Predicate::Year.new(
+        TestUser.get_field("created_at"),
+        ([Time.utc(2024, 1, 1), "2025"] of Marten::DB::Field::Any),
+        "table",
+        comparison_predicate: "in",
+      )
+
+      for_mysql do
+        predicate.to_sql(Marten::DB::Connection.default).should eq(
+          {"YEAR(table.created_at) IN ( %s , %s )", [2024_i64, 2025_i64]}
+        )
+      end
+
+      for_postgresql do
+        predicate.to_sql(Marten::DB::Connection.default).should eq(
+          {"EXTRACT(YEAR FROM table.created_at) IN ( %s , %s )", [2024_i64, 2025_i64]}
+        )
+      end
+
+      for_sqlite do
+        predicate.to_sql(Marten::DB::Connection.default).should eq(
+          {"CAST(STRFTIME('%Y', table.created_at) AS INTEGER) IN ( %s , %s )", [2024_i64, 2025_i64]}
+        )
+      end
+    end
+
+    it "returns the expected SQL statement for an isnull comparison predicate" do
+      predicate = Marten::DB::Query::SQL::Predicate::Year.new(
+        TestUser.get_field("created_at"),
+        true,
+        "table",
+        comparison_predicate: "isnull",
+      )
+
+      for_mysql do
+        predicate.to_sql(Marten::DB::Connection.default).should eq(
+          {"YEAR(table.created_at) IS NULL", [] of ::DB::Any}
+        )
+      end
+
+      for_postgresql do
+        predicate.to_sql(Marten::DB::Connection.default).should eq(
+          {"EXTRACT(YEAR FROM table.created_at) IS NULL", [] of ::DB::Any}
+        )
+      end
+
+      for_sqlite do
+        predicate.to_sql(Marten::DB::Connection.default).should eq(
+          {"CAST(STRFTIME('%Y', table.created_at) AS INTEGER) IS NULL", [] of ::DB::Any}
+        )
+      end
+    end
+
+    it "raises if the isnull comparison predicate does not receive a boolean" do
+      predicate = Marten::DB::Query::SQL::Predicate::Year.new(
+        TestUser.get_field("created_at"),
+        "false",
+        "table",
+        comparison_predicate: "isnull",
+      )
+
+      expect_raises(Marten::DB::Errors::UnmetQuerySetCondition, "'year__isnull' expects a boolean") do
+        predicate.to_sql(Marten::DB::Connection.default)
+      end
+    end
+  end
+end

--- a/spec/marten/db/query/sql/predicate_spec.cr
+++ b/spec/marten/db/query/sql/predicate_spec.cr
@@ -14,6 +14,8 @@ describe Marten::DB::Query::SQL::Predicate do
     it "returns the registered predicate implementations" do
       Marten::DB::Query::SQL::Predicate.registry["contains"].should eq(Marten::DB::Query::SQL::Predicate::Contains)
       Marten::DB::Query::SQL::Predicate.registry["exact"].should eq(Marten::DB::Query::SQL::Predicate::Exact)
+      Marten::DB::Query::SQL::Predicate.registry["year"].should eq(Marten::DB::Query::SQL::Predicate::Year)
+      Marten::DB::Query::SQL::Predicate.registry["second"].should eq(Marten::DB::Query::SQL::Predicate::Second)
     end
   end
 end

--- a/spec/marten/db/query/sql/query_spec.cr
+++ b/spec/marten/db/query/sql/query_spec.cr
@@ -199,6 +199,101 @@ describe Marten::DB::Query::SQL::Query do
       query.execute.to_set.should eq [post_1, post_3].to_set
     end
 
+    it "is able to process query nodes with transform-only time predicates on relations" do
+      year = Time.utc.year.to_i64
+      user_1 = TestUser.create!(username: "foo", email: "foo@example.com", first_name: "John", last_name: "Doe")
+      user_2 = TestUser.create!(username: "bar", email: "bar@example.com", first_name: "John", last_name: "Doe")
+
+      post_1 = Post.create!(author: user_1, title: "Post 1", updated_by: user_2)
+      post_2 = Post.create!(author: user_2, title: "Post 2", updated_by: user_1)
+      post_3 = Post.create!(author: user_1, title: "Post 3")
+
+      query = Marten::DB::Query::SQL::Query(Post).new
+      query.add_query_node(Marten::DB::Query::Node.new(author__created_at__year: year))
+      query.execute.to_set.should eq [post_1, post_2, post_3].to_set
+    end
+
+    it "is able to process query nodes with exact chained time predicates on relations" do
+      year = Time.utc.year.to_i64
+      user_1 = TestUser.create!(username: "foo", email: "foo@example.com", first_name: "John", last_name: "Doe")
+      user_2 = TestUser.create!(username: "bar", email: "bar@example.com", first_name: "John", last_name: "Doe")
+
+      post_1 = Post.create!(author: user_1, title: "Post 1", updated_by: user_2)
+      post_2 = Post.create!(author: user_2, title: "Post 2", updated_by: user_1)
+      post_3 = Post.create!(author: user_1, title: "Post 3")
+
+      query = Marten::DB::Query::SQL::Query(Post).new
+      query.add_query_node(Marten::DB::Query::Node.new(author__created_at__year__exact: year))
+      query.execute.to_set.should eq [post_1, post_2, post_3].to_set
+    end
+
+    it "is able to process query nodes with chained time predicates on relations" do
+      user_1 = TestUser.create!(username: "foo", email: "foo@example.com", first_name: "John", last_name: "Doe")
+      user_2 = TestUser.create!(username: "bar", email: "bar@example.com", first_name: "John", last_name: "Doe")
+
+      post_1 = Post.create!(author: user_1, title: "Post 1", updated_by: user_2)
+      post_2 = Post.create!(author: user_2, title: "Post 2", updated_by: user_1)
+      post_3 = Post.create!(author: user_1, title: "Post 3")
+
+      query = Marten::DB::Query::SQL::Query(Post).new
+      query.add_query_node(Marten::DB::Query::Node.new(author__created_at__month__gte: 1))
+      query.add_query_node(Marten::DB::Query::Node.new(author__created_at__hour__gte: 0))
+      query.execute.to_set.should eq [post_1, post_2, post_3].to_set
+    end
+
+    it "is able to process query nodes with in chained time predicates on relations" do
+      year = Time.utc.year.to_i64
+      user_1 = TestUser.create!(username: "foo", email: "foo@example.com", first_name: "John", last_name: "Doe")
+      user_2 = TestUser.create!(username: "bar", email: "bar@example.com", first_name: "John", last_name: "Doe")
+
+      post_1 = Post.create!(author: user_1, title: "Post 1", updated_by: user_2)
+      post_2 = Post.create!(author: user_2, title: "Post 2", updated_by: user_1)
+      post_3 = Post.create!(author: user_1, title: "Post 3")
+
+      query = Marten::DB::Query::SQL::Query(Post).new
+      query.add_query_node(
+        Marten::DB::Query::Node.new(
+          author__created_at__year__in: ([Time.utc(year.to_i, 1, 1), year.to_s] of Marten::DB::Field::Any)
+        )
+      )
+      query.execute.to_set.should eq [post_1, post_2, post_3].to_set
+    end
+
+    it "is able to process query nodes with isnull chained time predicates on relations" do
+      user_1 = TestUser.create!(username: "foo", email: "foo@example.com", first_name: "John", last_name: "Doe")
+      user_2 = TestUser.create!(username: "bar", email: "bar@example.com", first_name: "John", last_name: "Doe")
+
+      post_1 = Post.create!(author: user_1, title: "Post 1", updated_by: user_2)
+      post_2 = Post.create!(author: user_2, title: "Post 2", updated_by: user_1)
+      post_3 = Post.create!(author: user_1, title: "Post 3")
+
+      query = Marten::DB::Query::SQL::Query(Post).new
+      query.add_query_node(Marten::DB::Query::Node.new(author__created_at__year__isnull: false))
+      query.execute.to_set.should eq [post_1, post_2, post_3].to_set
+
+      query_with_null_check = Marten::DB::Query::SQL::Query(Post).new
+      query_with_null_check.add_query_node(Marten::DB::Query::Node.new(author__created_at__year__isnull: true))
+      query_with_null_check.execute.to_a.should be_empty
+    end
+
+    it "raises if unsupported chained predicate is used for a time predicate" do
+      query = Marten::DB::Query::SQL::Query(TestUser).new
+
+      expect_raises(Marten::DB::Errors::InvalidField) do
+        query.add_query_node(Marten::DB::Query::Node.new(created_at__year__contains: 2024))
+      end
+    end
+
+    it "raises if isnull chained time predicate does not receive a boolean" do
+      query = Marten::DB::Query::SQL::Query(TestUser).new
+
+      query.add_query_node(Marten::DB::Query::Node.new(created_at__year__isnull: "false"))
+
+      expect_raises(Marten::DB::Errors::UnmetQuerySetCondition, "'year__isnull' expects a boolean") do
+        query.execute.to_a
+      end
+    end
+
     it "is able to process query nodes with a direct filter on a relation model instance" do
       user_1 = TestUser.create!(username: "foo", email: "foo@example.com", first_name: "John", last_name: "Doe")
       user_2 = TestUser.create!(username: "bar", email: "bar@example.com", first_name: "John", last_name: "Doe")

--- a/spec/marten/db/query/sql/query_spec.cr
+++ b/spec/marten/db/query/sql/query_spec.cr
@@ -118,6 +118,17 @@ describe Marten::DB::Query::SQL::Query do
       query.execute.sort_by(&.pk!.to_s).should eq [tag_2, tag_3].sort_by(&.pk!.to_s)
     end
 
+    it "can add a raw filter containing a literal %s pattern and positional parameters" do
+      Tag.create!(name: "ruby", is_active: true)
+      tag_2 = Tag.create!(name: "crystal", is_active: true)
+      Tag.create!(name: "sapphire", is_active: true)
+
+      query = Marten::DB::Query::SQL::Query(Tag).new
+      query.add_query_node(Marten::DB::Query::Node.new("name LIKE '%s%' AND name != ?", ["sapphire"] of ::DB::Any))
+      query.count.should eq 1
+      query.execute.should eq [tag_2]
+    end
+
     it "can add a new filter to an already filtered query" do
       Tag.create!(name: "ruby", is_active: true)
       tag_2 = Tag.create!(name: "crystal", is_active: true)

--- a/src/marten/db/connection/mysql.cr
+++ b/src/marten/db/connection/mysql.cr
@@ -72,7 +72,8 @@ module Marten
         end
 
         def left_operand_for(id : String, predicate) : String
-          id
+          transformation = PREDICATE_TO_LEFT_OPERAND_TRANSFORMATION_MAPPING.fetch(predicate, nil)
+          transformation.nil? ? id : (transformation % id)
         end
 
         def limit_value(value : Int | Nil) : Int32 | Int64 | Nil | UInt32 | UInt64
@@ -137,6 +138,15 @@ module Marten
         end
 
         private DISTINCT_CLAUSE = "DISTINCT"
+
+        private PREDICATE_TO_LEFT_OPERAND_TRANSFORMATION_MAPPING = {
+          "year"   => "YEAR(%s)",
+          "month"  => "MONTH(%s)",
+          "day"    => "DAY(%s)",
+          "hour"   => "HOUR(%s)",
+          "minute" => "MINUTE(%s)",
+          "second" => "SECOND(%s)",
+        }
 
         private PREDICATE_TO_OPERATOR_MAPPING = {
           "contains"    => "LIKE BINARY %s",

--- a/src/marten/db/connection/postgresql.cr
+++ b/src/marten/db/connection/postgresql.cr
@@ -133,7 +133,7 @@ module Marten
           "day"         => "EXTRACT(DAY FROM %s)",
           "hour"        => "EXTRACT(HOUR FROM %s)",
           "minute"      => "EXTRACT(MINUTE FROM %s)",
-          "second"      => "EXTRACT(SECOND FROM %s)",
+          "second"      => "FLOOR(EXTRACT(SECOND FROM %s))",
         }
 
         private PREDICATE_TO_OPERATOR_MAPPING = {

--- a/src/marten/db/connection/postgresql.cr
+++ b/src/marten/db/connection/postgresql.cr
@@ -128,6 +128,12 @@ module Marten
           "iendswith"   => "UPPER(%s)",
           "iexact"      => "UPPER(%s)",
           "istartswith" => "UPPER(%s)",
+          "year"        => "EXTRACT(YEAR FROM %s)",
+          "month"       => "EXTRACT(MONTH FROM %s)",
+          "day"         => "EXTRACT(DAY FROM %s)",
+          "hour"        => "EXTRACT(HOUR FROM %s)",
+          "minute"      => "EXTRACT(MINUTE FROM %s)",
+          "second"      => "EXTRACT(SECOND FROM %s)",
         }
 
         private PREDICATE_TO_OPERATOR_MAPPING = {

--- a/src/marten/db/connection/sqlite.cr
+++ b/src/marten/db/connection/sqlite.cr
@@ -76,7 +76,8 @@ module Marten
         end
 
         def left_operand_for(id : String, predicate) : String
-          id
+          transformation = PREDICATE_TO_LEFT_OPERAND_TRANSFORMATION_MAPPING.fetch(predicate, nil)
+          transformation.nil? ? id : (transformation % id)
         end
 
         def limit_value(value : Int | Nil) : Int32 | Int64 | Nil | UInt32 | UInt64
@@ -130,6 +131,15 @@ module Marten
         end
 
         private DISTINCT_CLAUSE = "DISTINCT"
+
+        private PREDICATE_TO_LEFT_OPERAND_TRANSFORMATION_MAPPING = {
+          "year"   => "CAST(STRFTIME('%%Y', %s) AS INTEGER)",
+          "month"  => "CAST(STRFTIME('%%m', %s) AS INTEGER)",
+          "day"    => "CAST(STRFTIME('%%d', %s) AS INTEGER)",
+          "hour"   => "CAST(STRFTIME('%%H', %s) AS INTEGER)",
+          "minute" => "CAST(STRFTIME('%%M', %s) AS INTEGER)",
+          "second" => "CAST(STRFTIME('%%S', %s) AS INTEGER)",
+        }
 
         private PREDICATE_TO_OPERATOR_MAPPING = {
           "contains"    => "LIKE %s ESCAPE '\\'",

--- a/src/marten/db/query/sql/predicate.cr
+++ b/src/marten/db/query/sql/predicate.cr
@@ -7,6 +7,9 @@ module Marten
         module Predicate
           @@registry = {} of String => Base.class
 
+          TIME_PART_PREDICATE_TYPES       = %w(year month day hour minute second)
+          TIME_PART_COMPARISON_PREDICATES = %w(exact gt gte lt lte in isnull)
+
           def self.register(predicate_klass : Base.class)
             @@registry[predicate_klass.predicate_name] = predicate_klass
           end
@@ -15,11 +18,21 @@ module Marten
             @@registry
           end
 
+          def self.time_part_comparison_predicate?(name : String) : Bool
+            TIME_PART_COMPARISON_PREDICATES.includes?(name)
+          end
+
+          def self.time_part_predicate?(name : String) : Bool
+            TIME_PART_PREDICATE_TYPES.includes?(name)
+          end
+
           register Contains
+          register Day
           register EndsWith
           register Exact
           register GreaterThan
           register GreaterThanOrEqual
+          register Hour
           register IContains
           register IEndsWith
           register IExact
@@ -28,7 +41,11 @@ module Marten
           register IStartsWith
           register LessThan
           register LessThanOrEqual
+          register Minute
+          register Month
+          register Second
           register StartsWith
+          register Year
         end
       end
     end

--- a/src/marten/db/query/sql/predicate/base.cr
+++ b/src/marten/db/query/sql/predicate/base.cr
@@ -26,6 +26,7 @@ module Marten
             end
 
             protected getter left_operand
+            protected getter right_operand
 
             private def sql_left_operand(connection)
               case @left_operand

--- a/src/marten/db/query/sql/predicate/day.cr
+++ b/src/marten/db/query/sql/predicate/day.cr
@@ -12,7 +12,7 @@ module Marten
               value.day.to_i64
             end
 
-            protected def validate_coerced_value(value : Int64)
+            protected def validate_coerced_value!(value : Int64)
               return if value.in?(1_i64..31_i64)
 
               raise Errors::UnmetQuerySetCondition.new("'day' expects an integer between 1 and 31")

--- a/src/marten/db/query/sql/predicate/day.cr
+++ b/src/marten/db/query/sql/predicate/day.cr
@@ -1,0 +1,25 @@
+require "./time_part"
+
+module Marten
+  module DB
+    module Query
+      module SQL
+        module Predicate
+          class Day < TimePart
+            predicate_name "day"
+
+            protected def extract_time_part(value : Time) : Int64
+              value.day.to_i64
+            end
+
+            protected def validate_coerced_value(value : Int64)
+              return if value.in?(1_i64..31_i64)
+
+              raise Errors::UnmetQuerySetCondition.new("'day' expects an integer between 1 and 31")
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/src/marten/db/query/sql/predicate/hour.cr
+++ b/src/marten/db/query/sql/predicate/hour.cr
@@ -1,0 +1,33 @@
+require "./time_part"
+
+module Marten
+  module DB
+    module Query
+      module SQL
+        module Predicate
+          class Hour < TimePart
+            predicate_name "hour"
+
+            protected def allowed_field?(field : Field::Base) : Bool
+              field.is_a?(Field::DateTime)
+            end
+
+            protected def extract_time_part(value : Time) : Int64
+              value.hour.to_i64
+            end
+
+            protected def field_compatibility_error_message : String
+              "'hour' can only be used with date_time fields"
+            end
+
+            protected def validate_coerced_value(value : Int64)
+              return if value.in?(0_i64..23_i64)
+
+              raise Errors::UnmetQuerySetCondition.new("'hour' expects an integer between 0 and 23")
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/src/marten/db/query/sql/predicate/hour.cr
+++ b/src/marten/db/query/sql/predicate/hour.cr
@@ -20,7 +20,7 @@ module Marten
               "'hour' can only be used with date_time fields"
             end
 
-            protected def validate_coerced_value(value : Int64)
+            protected def validate_coerced_value!(value : Int64)
               return if value.in?(0_i64..23_i64)
 
               raise Errors::UnmetQuerySetCondition.new("'hour' expects an integer between 0 and 23")

--- a/src/marten/db/query/sql/predicate/minute.cr
+++ b/src/marten/db/query/sql/predicate/minute.cr
@@ -20,7 +20,7 @@ module Marten
               "'minute' can only be used with date_time fields"
             end
 
-            protected def validate_coerced_value(value : Int64)
+            protected def validate_coerced_value!(value : Int64)
               return if value.in?(0_i64..59_i64)
 
               raise Errors::UnmetQuerySetCondition.new("'minute' expects an integer between 0 and 59")

--- a/src/marten/db/query/sql/predicate/minute.cr
+++ b/src/marten/db/query/sql/predicate/minute.cr
@@ -1,0 +1,33 @@
+require "./time_part"
+
+module Marten
+  module DB
+    module Query
+      module SQL
+        module Predicate
+          class Minute < TimePart
+            predicate_name "minute"
+
+            protected def allowed_field?(field : Field::Base) : Bool
+              field.is_a?(Field::DateTime)
+            end
+
+            protected def extract_time_part(value : Time) : Int64
+              value.minute.to_i64
+            end
+
+            protected def field_compatibility_error_message : String
+              "'minute' can only be used with date_time fields"
+            end
+
+            protected def validate_coerced_value(value : Int64)
+              return if value.in?(0_i64..59_i64)
+
+              raise Errors::UnmetQuerySetCondition.new("'minute' expects an integer between 0 and 59")
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/src/marten/db/query/sql/predicate/month.cr
+++ b/src/marten/db/query/sql/predicate/month.cr
@@ -1,0 +1,25 @@
+require "./time_part"
+
+module Marten
+  module DB
+    module Query
+      module SQL
+        module Predicate
+          class Month < TimePart
+            predicate_name "month"
+
+            protected def extract_time_part(value : Time) : Int64
+              value.month.to_i64
+            end
+
+            protected def validate_coerced_value(value : Int64)
+              return if value.in?(1_i64..12_i64)
+
+              raise Errors::UnmetQuerySetCondition.new("'month' expects an integer between 1 and 12")
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/src/marten/db/query/sql/predicate/month.cr
+++ b/src/marten/db/query/sql/predicate/month.cr
@@ -12,7 +12,7 @@ module Marten
               value.month.to_i64
             end
 
-            protected def validate_coerced_value(value : Int64)
+            protected def validate_coerced_value!(value : Int64)
               return if value.in?(1_i64..12_i64)
 
               raise Errors::UnmetQuerySetCondition.new("'month' expects an integer between 1 and 12")

--- a/src/marten/db/query/sql/predicate/second.cr
+++ b/src/marten/db/query/sql/predicate/second.cr
@@ -1,0 +1,33 @@
+require "./time_part"
+
+module Marten
+  module DB
+    module Query
+      module SQL
+        module Predicate
+          class Second < TimePart
+            predicate_name "second"
+
+            protected def allowed_field?(field : Field::Base) : Bool
+              field.is_a?(Field::DateTime)
+            end
+
+            protected def extract_time_part(value : Time) : Int64
+              value.second.to_i64
+            end
+
+            protected def field_compatibility_error_message : String
+              "'second' can only be used with date_time fields"
+            end
+
+            protected def validate_coerced_value(value : Int64)
+              return if value.in?(0_i64..59_i64)
+
+              raise Errors::UnmetQuerySetCondition.new("'second' expects an integer between 0 and 59")
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/src/marten/db/query/sql/predicate/second.cr
+++ b/src/marten/db/query/sql/predicate/second.cr
@@ -20,7 +20,7 @@ module Marten
               "'second' can only be used with date_time fields"
             end
 
-            protected def validate_coerced_value(value : Int64)
+            protected def validate_coerced_value!(value : Int64)
               return if value.in?(0_i64..59_i64)
 
               raise Errors::UnmetQuerySetCondition.new("'second' expects an integer between 0 and 59")

--- a/src/marten/db/query/sql/predicate/time_part.cr
+++ b/src/marten/db/query/sql/predicate/time_part.cr
@@ -1,0 +1,148 @@
+module Marten
+  module DB
+    module Query
+      module SQL
+        module Predicate
+          abstract class TimePart < Base
+            def initialize(
+              left_operand : Annotation::Base | Field::Base,
+              right_operand : Field::Any | Array(Field::Any),
+              alias_prefix : String,
+              @comparison_predicate : String = "exact",
+            )
+              super(left_operand, right_operand, alias_prefix)
+            end
+
+            def to_sql(connection : Connection::Base)
+              validate_comparison_predicate!
+              validate_left_operand!
+
+              case @comparison_predicate
+              when "in"
+                to_sql_for_in(connection)
+              when "isnull"
+                to_sql_for_isnull(connection)
+              else
+                to_sql_for_scalar_comparison(connection)
+              end
+            end
+
+            protected def allowed_field?(field : Field::Base) : Bool
+              field.is_a?(Field::Date) || field.is_a?(Field::DateTime)
+            end
+
+            protected def field_compatibility_error_message : String
+              "'#{self.class.predicate_name}' can only be used with date or date_time fields"
+            end
+
+            protected def invalid_value_error_message : String
+              "'#{self.class.predicate_name}' expects an integer, a numeric string, or a Time value"
+            end
+
+            protected def validate_coerced_value(_value : Int64)
+            end
+
+            protected abstract def extract_time_part(value : Time) : Int64
+
+            private def coerce_value(value : Field::Any) : Int64
+              case value
+              when Int8, Int16, Int32, Int64
+                value.to_i64
+              when String
+                value.to_i64? || raise_invalid_value_error
+              when Time
+                extract_time_part(value)
+              else
+                raise_invalid_value_error
+              end
+            end
+
+            private def coerced_values_for_in_predicate : Array(Int64)
+              if !right_operand.is_a?(Array(Field::Any))
+                raise Errors::UnmetQuerySetCondition.new("In predicate requires an array of values")
+              end
+
+              values = right_operand.as(Array(Field::Any))
+              raise Errors::EmptyResults.new if values.empty?
+
+              values.map do |value|
+                coerced_value = coerce_value(value)
+                validate_coerced_value(coerced_value)
+                coerced_value
+              end
+            end
+
+            private def raise_invalid_value_error
+              raise Errors::UnmetQuerySetCondition.new(invalid_value_error_message)
+            end
+
+            private def sql_left_operand(connection)
+              field = left_operand.as(Field::Base)
+              connection.left_operand_for(
+                "#{alias_prefix}.#{field.db_column}",
+                self.class.predicate_name
+              )
+            end
+
+            private def validate_comparison_predicate!
+              return if Predicate.time_part_comparison_predicate?(@comparison_predicate)
+
+              raise Errors::InvalidField.new(
+                "Unsupported chained predicate type '#{@comparison_predicate}' for '#{self.class.predicate_name}'"
+              )
+            end
+
+            private def validate_left_operand!
+              if left_operand.is_a?(Annotation::Base)
+                raise Errors::InvalidField.new(
+                  "'#{self.class.predicate_name}' cannot be used with annotation values"
+                )
+              end
+
+              field = left_operand.as(Field::Base)
+              return if allowed_field?(field)
+
+              raise Errors::InvalidField.new(field_compatibility_error_message)
+            end
+
+            private def to_sql_for_in(connection : Connection::Base)
+              coerced_values = coerced_values_for_in_predicate
+
+              placeholders = String.build do |s|
+                s << "IN ( "
+                s << coerced_values.join(" , ") { "%s" }
+                s << " )"
+              end
+
+              sql_values = [] of ::DB::Any
+              coerced_values.each { |value| sql_values << value }
+
+              {"#{sql_left_operand(connection)} #{placeholders}", sql_values}
+            end
+
+            private def to_sql_for_isnull(connection : Connection::Base)
+              unless right_operand.is_a?(Bool)
+                raise Errors::UnmetQuerySetCondition.new("'#{self.class.predicate_name}__isnull' expects a boolean")
+              end
+
+              sql = right_operand.as(Bool) ? "IS NULL" : "IS NOT NULL"
+              {"#{sql_left_operand(connection)} #{sql}", [] of ::DB::Any}
+            end
+
+            private def to_sql_for_scalar_comparison(connection : Connection::Base)
+              if right_operand.is_a?(Array(Field::Any))
+                raise_invalid_value_error
+              end
+
+              coerced_value = coerce_value(right_operand.as(Field::Any))
+              validate_coerced_value(coerced_value)
+
+              operator = connection.operator_for(@comparison_predicate) % "%s"
+              {"#{sql_left_operand(connection)} #{operator}", [coerced_value] of ::DB::Any}
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/src/marten/db/query/sql/predicate/time_part.cr
+++ b/src/marten/db/query/sql/predicate/time_part.cr
@@ -39,7 +39,7 @@ module Marten
               "'#{self.class.predicate_name}' expects an integer, a numeric string, or a Time value"
             end
 
-            protected def validate_coerced_value(_value : Int64)
+            protected def validate_coerced_value!(_value : Int64)
             end
 
             protected abstract def extract_time_part(value : Time) : Int64
@@ -67,7 +67,7 @@ module Marten
 
               values.map do |value|
                 coerced_value = coerce_value(value)
-                validate_coerced_value(coerced_value)
+                validate_coerced_value!(coerced_value)
                 coerced_value
               end
             end
@@ -114,8 +114,7 @@ module Marten
                 s << " )"
               end
 
-              sql_values = [] of ::DB::Any
-              coerced_values.each { |value| sql_values << value }
+              sql_values = coerced_values.map(&.as(::DB::Any))
 
               {"#{sql_left_operand(connection)} #{placeholders}", sql_values}
             end
@@ -135,7 +134,7 @@ module Marten
               end
 
               coerced_value = coerce_value(right_operand.as(Field::Any))
-              validate_coerced_value(coerced_value)
+              validate_coerced_value!(coerced_value)
 
               operator = connection.operator_for(@comparison_predicate) % "%s"
               {"#{sql_left_operand(connection)} #{operator}", [coerced_value] of ::DB::Any}

--- a/src/marten/db/query/sql/predicate/year.cr
+++ b/src/marten/db/query/sql/predicate/year.cr
@@ -1,0 +1,19 @@
+require "./time_part"
+
+module Marten
+  module DB
+    module Query
+      module SQL
+        module Predicate
+          class Year < TimePart
+            predicate_name "year"
+
+            protected def extract_time_part(value : Time) : Int64
+              value.year.to_i64
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/src/marten/db/query/sql/query.cr
+++ b/src/marten/db/query/sql/query.cr
@@ -1025,20 +1025,7 @@ module Marten
           private def filtering_clause_and_parameters(predicate_node, offset = 0)
             if !predicate_node.nil?
               clause, parameters = predicate_node.to_sql(connection)
-              clause_parts = clause.split("%s")
-
-              if parameters.size != clause_parts.size - 1
-                raise Errors::InvalidField.new(
-                  "The number of parameters in the predicate node does not match the number of placeholders"
-                )
-              end
-
-              clause = String.build do |io|
-                clause_parts.each_with_index do |part, i|
-                  io << part
-                  io << connection.parameter_id_for_ordered_argument(offset + i + 1) if i < parameters.size
-                end
-              end
+              clause = replace_ordered_placeholders(clause, parameters.size, offset)
             else
               clause = nil
               parameters = nil
@@ -1195,6 +1182,49 @@ module Marten
             )
           end
 
+          private def replace_ordered_placeholders(clause : String, parameters_size : Int32, offset : Int32) : String
+            parameters_count = 0
+            chars = clause.chars
+
+            replaced_clause = String.build do |io|
+              i = 0
+
+              while i < chars.size
+                if chars[i] == '%'
+                  case chars[i + 1]?
+                  when '%'
+                    io << '%'
+                    i += 2
+                  when 's'
+                    if parameters_count >= parameters_size
+                      raise Errors::InvalidField.new(
+                        "The number of parameters in the predicate node does not match the number of placeholders"
+                      )
+                    end
+
+                    parameters_count += 1
+                    io << connection.parameter_id_for_ordered_argument(offset + parameters_count)
+                    i += 2
+                  else
+                    io << chars[i]
+                    i += 1
+                  end
+                else
+                  io << chars[i]
+                  i += 1
+                end
+              end
+            end
+
+            if parameters_count != parameters_size
+              raise Errors::InvalidField.new(
+                "The number of parameters in the predicate node does not match the number of placeholders"
+              )
+            end
+
+            replaced_clause
+          end
+
           private def raise_invalid_field_error_with_valid_choices(
             raw_field,
             model,
@@ -1276,9 +1306,9 @@ module Marten
 
                 begin
                   field_path = verify_field(raw_field)
-                rescue nested_error : Errors::InvalidField
+                rescue error : Errors::InvalidField
                   chained_time_part_lookup = parse_chained_time_part_lookup(raw_query)
-                  raise nested_error if chained_time_part_lookup.nil?
+                  raise error if chained_time_part_lookup.nil?
 
                   field_path = verify_field(chained_time_part_lookup.not_nil![:raw_field])
                   raw_predicate = chained_time_part_lookup.not_nil![:time_part_predicate]

--- a/src/marten/db/query/sql/query.cr
+++ b/src/marten/db/query/sql/query.cr
@@ -1184,36 +1184,10 @@ module Marten
 
           private def replace_ordered_placeholders(clause : String, parameters_size : Int32, offset : Int32) : String
             parameters_count = 0
-            chars = clause.chars
-
-            replaced_clause = String.build do |io|
-              i = 0
-
-              while i < chars.size
-                if chars[i] == '%'
-                  case chars[i + 1]?
-                  when '%'
-                    io << '%'
-                    i += 2
-                  when 's'
-                    if parameters_count >= parameters_size
-                      raise Errors::InvalidField.new(
-                        "The number of parameters in the predicate node does not match the number of placeholders"
-                      )
-                    end
-
-                    parameters_count += 1
-                    io << connection.parameter_id_for_ordered_argument(offset + parameters_count)
-                    i += 2
-                  else
-                    io << chars[i]
-                    i += 1
-                  end
-                else
-                  io << chars[i]
-                  i += 1
-                end
-              end
+            replaced_clause = clause.gsub(/%[%s]/) do |match|
+              next "%" if match == "%%"
+              parameters_count += 1
+              connection.parameter_id_for_ordered_argument(offset + parameters_count)
             end
 
             if parameters_count != parameters_size

--- a/src/marten/db/query/sql/query.cr
+++ b/src/marten/db/query/sql/query.cr
@@ -1025,10 +1025,19 @@ module Marten
           private def filtering_clause_and_parameters(predicate_node, offset = 0)
             if !predicate_node.nil?
               clause, parameters = predicate_node.to_sql(connection)
-              parameters.each_with_index do |_p, i|
-                clause = clause % (
-                  [connection.parameter_id_for_ordered_argument(offset + i + 1)] + (["%s"] * (parameters.size - i))
+              clause_parts = clause.split("%s")
+
+              if parameters.size != clause_parts.size - 1
+                raise Errors::InvalidField.new(
+                  "The number of parameters in the predicate node does not match the number of placeholders"
                 )
+              end
+
+              clause = String.build do |io|
+                clause_parts.each_with_index do |part, i|
+                  io << part
+                  io << connection.parameter_id_for_ordered_argument(offset + i + 1) if i < parameters.size
+                end
               end
             else
               clause = nil
@@ -1245,6 +1254,12 @@ module Marten
             qparts = raw_query.rpartition(Constants::LOOKUP_SEP)
             raw_field = qparts[1].empty? ? qparts[2] : qparts[0]
             raw_predicate = qparts[1].empty? ? qparts[0] : qparts[2]
+            chained_time_part_lookup : NamedTuple(
+              raw_field: String,
+              time_part_predicate: String,
+              comparison_predicate: String,
+            )? = nil
+            join = nil
 
             # First attempt to verify if the specified field corresponds to an existing annotation or an existing field.
             if !annotations[raw_query]?.nil?
@@ -1258,7 +1273,16 @@ module Marten
                 raw_predicate = nil
               rescue e : Errors::InvalidField
                 raise e if raw_predicate.try(&.empty?)
-                field_path = verify_field(raw_field)
+
+                begin
+                  field_path = verify_field(raw_field)
+                rescue nested_error : Errors::InvalidField
+                  chained_time_part_lookup = parse_chained_time_part_lookup(raw_query)
+                  raise nested_error if chained_time_part_lookup.nil?
+
+                  field_path = verify_field(chained_time_part_lookup.not_nil![:raw_field])
+                  raw_predicate = chained_time_part_lookup.not_nil![:time_part_predicate]
+                end
               end
 
               relation_field_path = field_path.select { |field, _r| field.relation? }
@@ -1291,6 +1315,19 @@ module Marten
               value = true
             elsif raw_predicate.nil?
               predicate_klass = Predicate::Exact
+            elsif Predicate.time_part_predicate?(raw_predicate)
+              predicate_klass = Predicate.registry.fetch(raw_predicate) do
+                raise Errors::InvalidField.new("Unknown predicate type '#{raw_predicate}'")
+              end
+
+              return predicate_klass
+                .as(Predicate::TimePart.class)
+                .new(
+                  left_operand,
+                  value,
+                  alias_prefix: join.nil? ? Model.db_table : join.not_nil!.table_alias,
+                  comparison_predicate: chained_time_part_lookup.try(&.[](:comparison_predicate)) || "exact"
+                )
             else
               predicate_klass = Predicate.registry.fetch(raw_predicate) do
                 raise Errors::InvalidField.new("Unknown predicate type '#{raw_predicate}'")
@@ -1298,6 +1335,30 @@ module Marten
             end
 
             predicate_klass.new(left_operand, value, alias_prefix: join.nil? ? Model.db_table : join.table_alias)
+          end
+
+          private def parse_chained_time_part_lookup(raw_query : String)
+            parts = raw_query.split(Constants::LOOKUP_SEP)
+            return if parts.size < 3
+
+            comparison_predicate = parts[-1]
+            time_part_predicate = parts[-2]
+            return unless Predicate.time_part_predicate?(time_part_predicate)
+
+            unless Predicate.time_part_comparison_predicate?(comparison_predicate)
+              raise Errors::InvalidField.new(
+                "Unsupported chained predicate type '#{comparison_predicate}' for '#{time_part_predicate}'"
+              )
+            end
+
+            raw_field = parts[0..-3].join(Constants::LOOKUP_SEP)
+            return if raw_field.empty?
+
+            {
+              raw_field:            raw_field,
+              time_part_predicate:  time_part_predicate,
+              comparison_predicate: comparison_predicate,
+            }
           end
 
           private def solve_plucked_fields_and_columns(fields)


### PR DESCRIPTION
This PR introduces time-based field transforms that allow filtering records based on
specific components of date and datetime fields (year, month, day, hour, minute, second).

## What's New

Field Transforms Available:
- year - Extract year from date/datetime fields
- month - Extract month from date/datetime fields
- day - Extract day of month from date/datetime fields
- hour - Extract hour from datetime fields
- minute - Extract minute from datetime fields
- second - Extract second from datetime fields

By default each time predicate will be combined with the `exact` predicate, but they can be combined with any other non-transform predicate, e.g. `created_at__year__lt`.

Closes #237 