### PR TITLE
fix typo in --log-level help placeholder

### DIFF
--- a/src/marten.cr
+++ b/src/marten.cr
@@ -309,7 +309,7 @@ module Marten
         puts opts
         exit 0
       end
-      opts.on("--log-level PORT", "Custom log level to use") do |log_level|
+      opts.on("--log-level LOG_LEVEL", "Custom log level to use") do |log_level|
         override_log_level(log_level)
       end
     end


### PR DESCRIPTION
Update the `--log-level` option help text to use `LOG_LEVEL`` instead of `PORT`, ensuring consistency with the argument’s purpose.