### PR TITLE
feat: add JSON representation for Marten::HTTP::UploadedFile

### DIFF
--- a/spec/marten/http/uploaded_file_spec.cr
+++ b/spec/marten/http/uploaded_file_spec.cr
@@ -59,8 +59,7 @@ describe Marten::HTTP::UploadedFile do
         )
       )
       actual = JSON.parse(uploaded_file.to_json).as_h
-      actual.keys.sort!.should eq ["content_type", "original_filename", "tempfile"]
-      actual["content_type"].should eq "text/plain"
+      actual.keys.sort!.should eq ["original_filename", "tempfile"]
       actual["original_filename"].should eq "a.txt"
       actual["tempfile"].as_s.matches?(/\#<File:.*>/).should be_true
     end

--- a/src/marten/http/uploaded_file.cr
+++ b/src/marten/http/uploaded_file.cr
@@ -7,7 +7,7 @@ module Marten
       # Returns the `File` object associated with the corresponding temporary file.
       getter io
 
-      def initialize(@part : ::HTTP::FormData::Part, @ct : String = "text/plain")
+      def initialize(@part : ::HTTP::FormData::Part)
         @io = File.tempfile
         ::File.open(@io.as(File).path, "w") do |file|
           IO.copy(@part.body, file)
@@ -22,7 +22,6 @@ module Marten
         json.object do
           json.field "original_filename", @part.filename
           json.field "tempfile", @io.inspect
-          json.field "content_type", @ct
         end
       end
 


### PR DESCRIPTION
This change introduces a `to_json` method to `Marten::HTTP::UploadedFile`, allowing uploaded files to be included in JSON representations such as `request.data.to_json`.

Previously, converting a request containing an uploaded file to JSON raised:

    Error: expected argument #1 to 'Marten::HTTP::UploadedFile#to_json' to be IO, not JSON::Builder

The new implementation defines `#to_json` and `#to_json(json : JSON::Builder)`, returning an object with the following fields:
- `original_filename`
- `tempfile`
- `content_type`

This makes it possible to safely serialize uploaded files in request data.

I was inspired by ruby rack implementation ([src](https://www.rubydoc.info/gems/rack/Rack/Multipart/UploadedFile)):

```ruby
puts Rack::Multipart::UploadedFile.new("/usr/bin/nvim").to_json
{"original_filename":"nvim","tempfile":"#<File:0x00007f2e4d386648>","content_type":"text/plain"}
```