### PR TITLE
Add request `remote_ip` accessor

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -30,6 +30,7 @@ development_dependencies:
     github: crystal-lang/crystal-sqlite3
   timecop:
     github: crystal-community/timecop.cr
+    commit: 85a4fb2
   vips:
     github: naqvis/crystal-vips
 

--- a/spec/marten/http/request_spec.cr
+++ b/spec/marten/http/request_spec.cr
@@ -968,6 +968,23 @@ describe Marten::HTTP::Request do
     end
   end
 
+  describe "#remote_ip_address" do
+    it "returns the peer IPv4 address when present" do
+      raw_request = HTTP::Request.new("GET", "/")
+      raw_request.remote_address = Socket::IPAddress.new("203.0.113.10", 12345)
+
+      request = Marten::HTTP::Request.new(raw_request)
+
+      request.remote_ip_address.should eq("203.0.113.10")
+    end
+
+    it "returns nil when the peer address is missing" do
+      request = Marten::HTTP::Request.new(HTTP::Request.new("GET", "/"))
+
+      request.remote_ip_address.should be_nil
+    end
+  end
+
   describe "#scheme" do
     around_each do |t|
       original_use_x_forwarded_proto = Marten.settings.use_x_forwarded_proto

--- a/src/marten/http/request.cr
+++ b/src/marten/http/request.cr
@@ -163,6 +163,11 @@ module Marten
         @query_parans ||= Params::Query.new(extract_raw_query_params)
       end
 
+      # Returns the direct peer IP of the incoming TCP connection (if available).
+      def remote_ip_address : String?
+        @request.remote_address.as?(Socket::IPAddress).try(&.address)
+      end
+
       # Returns the scheme of the request (either `"http"` or `"https"`).
       def scheme : String
         @scheme ||= begin


### PR DESCRIPTION
This PR adds a small convenience helper to `Marten::HTTP::Request`: `#remote_ip_address : String?`.

It exposes the **direct TCP peer IP** by reading the underlying `HTTP::Request#remote_address` and returning the IP when it’s a `Socket::IPAddress` (otherwise `nil`). 