### PR TITLE
Add email attachment support

### DIFF
--- a/docs/docs/emailing/callbacks.md
+++ b/docs/docs/emailing/callbacks.md
@@ -60,6 +60,8 @@ class WelcomeEmail < Marten::Email
 end
 ```
 
+This callback is also a common place to call [`#attach`](./introduction.md#defining-attachments) in order to add email attachments right before delivery.
+
 ### `after_deliver`
 
 `after_deliver` callbacks are executed _after_ an email is delivered (as part of the email's [`#deliver`](pathname:///api/dev/Marten/Emailing/Email.html#deliver-instance-method) method). For example, such callbacks can be leveraged to increment email-specific metrics:

--- a/docs/docs/emailing/how-to/create-custom-emailing-backends.md
+++ b/docs/docs/emailing/how-to/create-custom-emailing-backends.md
@@ -19,6 +19,29 @@ class CustomEmailingBackend < Marten::Emailing::Backend::Base
 end
 ```
 
+## Handling attachments
+
+If your backend supports attachments, you can iterate over [`#attachments`](pathname:///api/dev/Marten/Emailing/Email.html) in the `#deliver` implementation:
+
+```crystal
+class CustomEmailingBackend < Marten::Emailing::Backend::Base
+  def deliver(email : Email)
+    email.attachments.each do |attachment|
+      # attachment.filename
+      # attachment.mime_type
+      # attachment.content
+    end
+  end
+end
+```
+
+Each attachment exposes:
+
+* a `filename`
+* a `mime_type`
+* a `content` byte slice
+* a `size` in bytes
+
 ## Enabling the use of custom emailing backends
 
 Custom emailing backends can be used by assigning an instance of the corresponding class to the [`emailing.backend`](../../development/reference/settings.md#backend-1) setting.

--- a/docs/docs/emailing/introduction.md
+++ b/docs/docs/emailing/introduction.md
@@ -128,6 +128,46 @@ class WelcomeEmail < Marten::Email
 end
 ```
 
+### Defining attachments
+
+Attachments can be associated with an email by calling [`#attach`](pathname:///api/dev/Marten/Emailing/Email.html#attach(path%3AString,filename%3AString%7CNil%3Dnil,mime_type%3AString%7CNil%3Dnil)%3ANil-instance-method). In most cases, this is done in a [`before_deliver`](./callbacks.md#before_deliver) callback so that attachments are set right before the email is delivered.
+
+The following `#attach` method signatures are available:
+
+* `attach(path : String, filename : String? = nil, mime_type : String? = nil)`
+* `attach(file : File, filename : String? = nil, mime_type : String? = nil)`
+* `attach(io : IO, *, filename : String, mime_type : String? = nil)`
+
+:::note[IO Attachments]
+When using `attach(io, ...)`, the `filename` is required and the IO is read from its current position to EOF. If you need to attach the full IO content, call `io.rewind` before attaching it.
+:::
+
+For example:
+
+```crystal
+class WelcomeEmail < Marten::Email
+  from "no-reply@martenframework.com"
+  to @user.email
+  subject "Hello!"
+  template_name "emails/welcome_email.html"
+
+  before_deliver :add_attachments
+
+  def initialize(@user : User)
+  end
+
+  private def add_attachments
+    # Attach a file from a path.
+    attach "public/docs/terms.pdf"
+
+    # Attach generated content from an IO.
+    attach generate_pdf_io(@user), filename: "welcome.pdf", mime_type: "application/pdf"
+  end
+end
+```
+
+When a `mime_type` is not specified, Marten infers it from the attachment file name. If no MIME type can be inferred, it defaults to `application/octet-stream`.
+
 ## Sending emails
 
 Emails are sent _synchronously_ through the use of the [`#deliver`](pathname:///api/dev/Marten/Emailing/Email.html#deliver-instance-method). For example, the `WelcomeEmail` email defined in the previous sections could be initialized and delivered by doing:

--- a/spec/marten/emailing/backend/development_spec.cr
+++ b/spec/marten/emailing/backend/development_spec.cr
@@ -140,6 +140,30 @@ describe Marten::Emailing::Backend::Development do
           OUTPUT
       )
     end
+
+    it "outputs an email with attachments as expected if this capability is activated" do
+      stdout = IO::Memory.new
+
+      email = Marten::Emailing::Backend::DevelopmentSpec::TestEmailWithAttachment.new
+      backend = Marten::Emailing::Backend::Development.new(print_emails: true, stdout: stdout)
+
+      backend.deliver(email)
+
+      stdout.rewind
+      stdout.gets_to_end.should eq(
+        <<-OUTPUT
+          From: webmaster@localhost
+          To: test@example.com
+          Subject: Hello World!
+          Attachments:
+          - test_attachment.txt (text/plain, 18 bytes)
+          ---------- TEXT ----------
+          Text body
+          ---------- HTML ----------
+          HTML body
+          OUTPUT
+      )
+    end
   end
 
   describe "#delivered_emails" do
@@ -195,6 +219,12 @@ module Marten::Emailing::Backend::DevelopmentSpec
 
     def headers
       {"foo" => "bar"}
+    end
+  end
+
+  class TestEmailWithAttachment < TestEmail
+    def initialize
+      attach(IO::Memory.new("Attachment content"), filename: "test_attachment.txt")
     end
   end
 end

--- a/spec/marten/emailing/email_spec.cr
+++ b/spec/marten/emailing/email_spec.cr
@@ -169,6 +169,114 @@ describe Marten::Emailing::Email do
     end
   end
 
+  describe "#attachments" do
+    it "returns an empty array by default" do
+      email = Marten::Emailing::EmailSpec::EmailWithoutConfiguration.new
+      email.attachments.should be_empty
+    end
+  end
+
+  describe "#attach" do
+    it "allows to attach a file from a path while inferring the file name and MIME type" do
+      tempfile = File.tempfile("email_attachment", ".txt")
+      tempfile.print("Path attachment content")
+      tempfile.close
+      path = tempfile.path
+
+      begin
+        email = Marten::Emailing::EmailSpec::EmailWithoutConfiguration.new
+        email.attach(path)
+
+        email.attachments.size.should eq 1
+        attachment = email.attachments.first
+
+        attachment.filename.should eq Path[path].basename
+        attachment.mime_type.should eq MIME.from_filename(path)
+        String.new(attachment.content).should eq "Path attachment content"
+      ensure
+        File.delete(path) if File.exists?(path)
+      end
+    end
+
+    it "allows to attach a file from a path with a custom file name and MIME type" do
+      tempfile = File.tempfile("email_attachment", ".txt")
+      tempfile.print("Path attachment content")
+      tempfile.close
+      path = tempfile.path
+
+      begin
+        email = Marten::Emailing::EmailSpec::EmailWithoutConfiguration.new
+        email.attach(path, filename: "welcome.pdf", mime_type: "application/pdf")
+
+        email.attachments.size.should eq 1
+        attachment = email.attachments.first
+
+        attachment.filename.should eq "welcome.pdf"
+        attachment.mime_type.should eq "application/pdf"
+        String.new(attachment.content).should eq "Path attachment content"
+      ensure
+        File.delete(path) if File.exists?(path)
+      end
+    end
+
+    it "allows to attach a file from a File object" do
+      file = File.tempfile("email_attachment", ".txt")
+      path = file.path
+      file.print("File object attachment content")
+      file.rewind
+
+      begin
+        file.read_string(5).should eq "File "
+
+        email = Marten::Emailing::EmailSpec::EmailWithoutConfiguration.new
+        email.attach(file)
+
+        email.attachments.size.should eq 1
+        attachment = email.attachments.first
+
+        attachment.filename.should eq Path[path].basename
+        attachment.mime_type.should eq MIME.from_filename(path)
+        String.new(attachment.content).should eq "File object attachment content"
+      ensure
+        file.close
+        File.delete(path) if File.exists?(path)
+      end
+    end
+
+    it "allows to attach an IO by reading from its current position" do
+      email = Marten::Emailing::EmailSpec::EmailWithoutConfiguration.new
+
+      io = IO::Memory.new("IO memory attachment content")
+      io.read_string(10).should eq "IO memory "
+
+      email.attach(io, filename: "welcome.txt")
+
+      email.attachments.size.should eq 1
+      attachment = email.attachments.first
+
+      attachment.filename.should eq "welcome.txt"
+      attachment.mime_type.should eq "text/plain"
+      String.new(attachment.content).should eq "attachment content"
+    end
+
+    it "falls back to application/octet-stream for unknown extensions" do
+      tempfile = File.tempfile("email_attachment", ".unknown_extension")
+      tempfile.print("Unknown extension content")
+      tempfile.close
+      path = tempfile.path
+
+      begin
+        email = Marten::Emailing::EmailSpec::EmailWithoutConfiguration.new
+        email.attach(path)
+
+        email.attachments.size.should eq 1
+        email.attachments.first.mime_type.should eq "application/octet-stream"
+      ensure
+        File.delete(path) if File.exists?(path)
+      end
+    end
+  end
+
   describe "#bcc" do
     it "returns nil by default" do
       email = Marten::Emailing::EmailSpec::EmailWithoutConfiguration.new
@@ -214,6 +322,22 @@ describe Marten::Emailing::Email do
 
       email.foo.should eq "set_foo"
       email.bar.should eq "set_bar"
+    end
+
+    it "allows before_deliver callbacks to attach files" do
+      Marten::Emailing::EmailSpec::TEST_BACKEND.delivered.clear
+
+      email = Marten::Emailing::EmailSpec::EmailWithAttachmentCallback.new
+      email.deliver
+
+      Marten::Emailing::EmailSpec::TEST_BACKEND.delivered.includes?(email).should be_true
+
+      email.attachments.size.should eq 1
+      attachment = email.attachments.first
+
+      attachment.filename.should eq "callback_attachment.txt"
+      attachment.mime_type.should eq "text/plain"
+      String.new(attachment.content).should eq "Callback attachment content"
     end
   end
 
@@ -483,6 +607,16 @@ module Marten::Emailing::EmailSpec
 
     private def set_bar
       self.bar = "set_bar"
+    end
+  end
+
+  class EmailWithAttachmentCallback < Marten::Emailing::Email
+    backend TEST_BACKEND
+
+    before_deliver :attach_generated_content
+
+    private def attach_generated_content
+      attach(IO::Memory.new("Callback attachment content"), filename: "callback_attachment.txt")
     end
   end
 end

--- a/src/marten/emailing/attachment.cr
+++ b/src/marten/emailing/attachment.cr
@@ -1,0 +1,26 @@
+module Marten
+  module Emailing
+    # Represents an email attachment.
+    struct Attachment
+      @content : Bytes
+
+      # Returns the attached file name.
+      getter filename
+
+      # Returns the attachment MIME type.
+      getter mime_type
+
+      # Returns the attached content bytes.
+      getter content
+
+      def initialize(@filename : String, @mime_type : String, content : Bytes)
+        @content = content.dup
+      end
+
+      # Returns the attachment size in bytes.
+      def size : Int32
+        content.size
+      end
+    end
+  end
+end

--- a/src/marten/emailing/backend/development.cr
+++ b/src/marten/emailing/backend/development.cr
@@ -37,6 +37,13 @@ module Marten
           parts << "Subject: #{email.subject}"
           parts << "Headers: #{email.headers}" unless email.headers.empty?
 
+          unless email.attachments.empty?
+            parts << "Attachments:"
+            email.attachments.each do |attachment|
+              parts << "- #{attachment.filename} (#{attachment.mime_type}, #{attachment.size} bytes)"
+            end
+          end
+
           if !(text = email.text_body).nil?
             parts << "---------- TEXT ----------"
             parts << text

--- a/src/marten/emailing/email.cr
+++ b/src/marten/emailing/email.cr
@@ -1,3 +1,4 @@
+require "./attachment"
 require "./email/callbacks"
 
 module Marten
@@ -10,6 +11,7 @@ module Marten
     abstract class Email
       include Callbacks
 
+      @attachments = [] of Attachment
       @context : Template::Context? = nil
       @headers = {} of String => String
 
@@ -43,6 +45,37 @@ module Marten
       # Returns the emailing backend to use in order to send this email.
       def backend
         self.class.backend || Marten.settings.emailing.backend
+      end
+
+      # Attaches the file located at the specified path.
+      def attach(path : String, filename : String? = nil, mime_type : String? = nil) : Nil
+        attachment_filename = filename || Path[path].basename
+        File.open(path) do |file|
+          attach_content(file, attachment_filename, mime_type)
+        end
+      end
+
+      # Attaches the specified file.
+      def attach(file : ::File, filename : String? = nil, mime_type : String? = nil) : Nil
+        attachment_filename = filename || Path[file.path].basename
+        initial_position = file.pos
+
+        begin
+          file.rewind
+          attach_content(file, attachment_filename, mime_type)
+        ensure
+          file.pos = initial_position
+        end
+      end
+
+      # Attaches the content read from the specified IO.
+      def attach(io : IO, *, filename : String, mime_type : String? = nil) : Nil
+        attach_content(io, filename, mime_type)
+      end
+
+      # Returns the associated attachments.
+      def attachments : Array(Attachment)
+        @attachments
       end
 
       # Returns the email addresses the email should be BBC'ed to.
@@ -166,6 +199,8 @@ module Marten
         end
       end
 
+      private DEFAULT_ATTACHMENT_MIME_TYPE = "application/octet-stream"
+
       private def normalize(value : Array(Address) | Array(String) | Address | String) : Array(Address)
         case value
         when Array(Address)
@@ -184,6 +219,24 @@ module Marten
         run_before_render_callbacks
 
         Marten.templates.get_template(template_name).render(context)
+      end
+
+      private def resolve_attachment_mime_type(filename : String, mime_type : String?) : String
+        return mime_type.not_nil! unless mime_type.nil?
+
+        begin
+          MIME.from_filename(filename)
+        rescue KeyError
+          DEFAULT_ATTACHMENT_MIME_TYPE
+        end
+      end
+
+      private def attach_content(io : IO, filename : String, mime_type : String?) : Nil
+        attachments << Attachment.new(
+          filename: filename,
+          mime_type: resolve_attachment_mime_type(filename, mime_type),
+          content: io.gets_to_end.to_slice
+        )
       end
     end
   end


### PR DESCRIPTION
This PR introduces e-mail attachment support to Marten's emailing system.

It adds a attachment struct and new `attach` helpers for file paths, `File` instances, and generic `IO` objects. MIME types are inferred from the filename when possible, with a fallback to `application/octet-stream`.

The change also makes attachments accessible to other backends and includes attachment details in the development backend output.

Closes #320 