### PR TITLE
feat: allow hash keys to be resolved as template attributes

### DIFF
--- a/spec/marten/template/ext/hash_spec.cr
+++ b/spec/marten/template/ext/hash_spec.cr
@@ -46,5 +46,24 @@ describe Hash do
     it "returns the expected result when requesting the 'values' attribute" do
       ({"a" => 1, "b" => 2, "c" => 3} of String => Int32).resolve_template_attribute("values").should eq [1, 2, 3]
     end
+
+    it "returns the value for a hash key used as attribute" do
+      ({"type" => "abonnement", "montant" => "60.00"} of String => String)
+        .resolve_template_attribute("type").should eq "abonnement"
+    end
+
+    it "returns the value for a hash key with integer values" do
+      ({"count" => 42} of String => Int32).resolve_template_attribute("count").should eq 42
+    end
+
+    it "falls back to standard attributes when key does not exist" do
+      ({"a" => 1} of String => Int32).resolve_template_attribute("size").should eq 1
+    end
+
+    it "raises UnknownVariable for non-existent key and non-existent attribute" do
+      expect_raises(Marten::Template::Errors::UnknownVariable) do
+        ({"a" => 1} of String => Int32).resolve_template_attribute("xyz")
+      end
+    end
   end
 end

--- a/src/marten/template/ext/hash.cr
+++ b/src/marten/template/ext/hash.cr
@@ -3,4 +3,16 @@ class Hash
   include Marten::Template::CanDefineTemplateAttributes
 
   template_attributes :any?, :compact, :empty?, :keys, :none?, :one?, :present?, :size, :values
+
+  # Allows to resolve hash keys as template attributes.
+  #
+  # This makes it possible to access hash values using `{{ my_hash.my_key }}` in templates,
+  # in addition to the standard hash methods (empty?, size, keys, etc.).
+  def resolve_template_attribute(key : ::String)
+    if has_key?(key)
+      self[key]
+    else
+      previous_def
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Allow `Hash` keys to be used as template attributes, so that `{{ my_hash.my_key }}` resolves to the value associated with `my_key`.

**Before:** Only methods listed in `template_attributes` (like `empty?`, `size`, `keys`) were accessible. Hash keys were silently ignored, resulting in empty values with no error — a common pitfall.

**After:** Hash keys are resolved first, with a fallback to the standard `template_attributes` methods.

## Motivation

When passing a `Hash(String, String)` to a template context:

```crystal
render "my_template.html", context: {
  item: {"type" => "order", "amount" => "60.00"},
}
```

Users expect `{{ item.type }}` to output `order`. Instead, it silently outputs nothing because `Hash` only exposes methods like `empty?` and `size` to the template engine.

This is particularly confusing because:
- No error is raised — values are just empty
- `NamedTuple` works as expected via `Object::Auto`
- The fix is non-obvious (requires creating a custom struct with `Object::Auto`)

## Changes

- **`src/marten/template/ext/hash.cr`**: Override `resolve_template_attribute` to check `has_key?(key)` before falling back to the macro-generated method
- **`spec/marten/template/ext/hash_spec.cr`**: 4 new tests covering key access, fallback to standard attributes, and error on unknown keys

## Test plan

- [x] Existing hash spec tests still pass (9 tests)
- [x] New tests for key access (4 tests)
- [x] `size` attribute still works when a key named `size` does not exist (fallback)
- [x] `UnknownVariable` is raised for non-existent keys that are not standard attributes