### PR TITLE
feat: add render_partial for HTMX fragment responses

### DIFF
--- a/spec/marten/handlers/base_spec.cr
+++ b/spec/marten/handlers/base_spec.cr
@@ -1146,6 +1146,55 @@ describe Marten::Handlers::Base do
       handler.url("dummy_with_id", id: 42).should eq Marten.routes.reverse("dummy_with_id", id: 42)
     end
   end
+
+  describe "#render_partial" do
+    it "renders a template without context producers or layout" do
+      request = Marten::HTTP::Request.new(
+        ::HTTP::Request.new(
+          method: "GET",
+          resource: "",
+          headers: HTTP::Headers{"Host" => "example.com"}
+        )
+      )
+
+      handler = Marten::Handlers::BaseSpec::Test5Handler.new(request)
+      response = handler.render_partial("specs/handlers/base/test.html", context: {"name" => "Partial"})
+
+      response.status.should eq 200
+      response.content.strip.should eq "Hello World, Partial!"
+    end
+
+    it "renders a partial with a named tuple context" do
+      request = Marten::HTTP::Request.new(
+        ::HTTP::Request.new(
+          method: "GET",
+          resource: "",
+          headers: HTTP::Headers{"Host" => "example.com"}
+        )
+      )
+
+      handler = Marten::Handlers::BaseSpec::Test5Handler.new(request)
+      response = handler.render_partial("specs/handlers/base/test.html", context: {name: "Tuple"})
+
+      response.status.should eq 200
+      response.content.strip.should eq "Hello World, Tuple!"
+    end
+
+    it "renders a partial with a custom status code" do
+      request = Marten::HTTP::Request.new(
+        ::HTTP::Request.new(
+          method: "GET",
+          resource: "",
+          headers: HTTP::Headers{"Host" => "example.com"}
+        )
+      )
+
+      handler = Marten::Handlers::BaseSpec::Test5Handler.new(request)
+      response = handler.render_partial("specs/handlers/base/test.html", context: {"name" => "Test"}, status: 201)
+
+      response.status.should eq 201
+    end
+  end
 end
 
 module Marten::Handlers::BaseSpec

--- a/src/marten/handlers/base.cr
+++ b/src/marten/handlers/base.cr
@@ -239,6 +239,32 @@ module Marten
         end
       end
 
+      # Renders a template without the layout, context producers, or before_render callbacks.
+      #
+      # This is useful for returning HTML fragments (e.g. for HTMX responses) where the full
+      # page layout should not be included.
+      #
+      # ```
+      # def post
+      #   render_partial("shared/_item.html", context: {item: item}, status: 200)
+      # end
+      # ```
+      def render_partial(
+        template_name : String,
+        context : Hash | NamedTuple | Nil | Marten::Template::Context = nil,
+        content_type = HTTP::Response::DEFAULT_CONTENT_TYPE,
+        status : ::HTTP::Status | Int32 = 200,
+      )
+        ctx = Marten::Template::Context.new
+        ctx.merge(context) unless context.nil?
+
+        HTTP::Response.new(
+          content: Marten.templates.get_template(template_name).render(ctx),
+          content_type: content_type,
+          status: ::HTTP::Status.new(status).to_i
+        )
+      end
+
       # Returns an HTTP response generated from a content string, content type and status code.
       def respond(
         content = "",


### PR DESCRIPTION
## Summary

Add a `render_partial` method to `Marten::Handlers::Base` that renders a template **without** the layout, context producers, or `before_render` callbacks.

## Motivation

HTMX is increasingly popular for building interactive web applications. A common pattern is returning HTML fragments from handlers to replace parts of the page:

```crystal
def post
  # Update something...
  render_partial("shared/_item_card.html", context: {item: item})
end
```

Currently, developers must work around this by manually loading and rendering templates:

```crystal
tpl = Marten.templates.get_template("shared/_item_card.html")
ctx = Marten::Template::Context{"item" => item}
Marten::HTTP::Response.new(tpl.render(ctx), content_type: "text/html", status: 200)
```

This is verbose, error-prone, and bypasses the handler's response infrastructure.

## Changes

- **`src/marten/handlers/base.cr`**: New `render_partial` method that creates a clean `Context` (no producers), renders the template, and returns an `HTTP::Response`
- **`spec/marten/handlers/base_spec.cr`**: 3 tests (hash context, named tuple context, custom status)

## Design decisions

- **No context producers**: Partials are fragments — they should not include layout-level data
- **No `before_render` callbacks**: These are designed for full-page renders
- **No `request` in context**: Keeps the partial isolated. If needed, the caller can add it explicitly
- Supports `Hash`, `NamedTuple`, `Context`, and `nil`

## Related

- Issue #165 (Component template tag) — `render_partial` addresses the server-side use case

## Test plan

- [x] Renders template with hash context
- [x] Renders template with named tuple context  
- [x] Custom status code works
- [x] All 71 existing handler base tests still pass