### PR TITLE
chore: enable Dependabot for npm (docs) and GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,39 @@
+# Dependabot configuration
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+#
+# Note: Crystal `shards` are not currently a supported ecosystem, so only the
+# documentation site and GitHub Actions workflows are tracked here.
+
+version: 2
+updates:
+  # Documentation site (Docusaurus)
+  - package-ecosystem: "npm"
+    directory: "/docs"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "documentation"
+    groups:
+      docusaurus:
+        patterns:
+          - "@docusaurus/*"
+          - "@mdx-js/*"
+      babel:
+        patterns:
+          - "@babel/*"
+      dev-dependencies:
+        dependency-type: "development"
+
+  # GitHub Actions workflows
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "ci"


### PR DESCRIPTION
## Summary

Adds a `.github/dependabot.yml` to enable Dependabot version updates on the two ecosystems supported in this repository:

- **`/docs` (npm)** — keeps Docusaurus, Babel and other documentation dependencies patched.
- **`/` (github-actions)** — keeps reusable actions used by the workflows (`specs.yml`, `qa.yml`, etc.) up to date.

Schedule is **weekly (Monday)** with a cap of 5 open PRs per ecosystem. Documentation bumps are grouped (Docusaurus / Babel / dev-dependencies) to minimize PR noise.

> Note: Crystal `shards` is not a Dependabot-supported ecosystem at this time, so `shard.yml` deps remain out of scope.

## Motivation

Three transitive **high-severity advisories** sat in the dual lockfiles (`docs/yarn.lock` and `docs/package-lock.json`) for weeks without being noticed:

- [GHSA-fv7c-fp4j-7gwp](https://github.com/advisories/GHSA-fv7c-fp4j-7gwp) — `@babel/plugin-transform-modules-systemjs` (arbitrary code generation)
- [GHSA-q3j6-qgpj-74h6](https://github.com/advisories/GHSA-q3j6-qgpj-74h6) — `fast-uri` (path traversal)
- [GHSA-v39h-62p7-jpjc](https://github.com/advisories/GHSA-v39h-62p7-jpjc) — `fast-uri` (host confusion)

The bumps themselves are addressed in #362. Enabling Dependabot prevents this kind of oversight from recurring.

## Test plan

- [x] YAML is valid against the [Dependabot configuration schema](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file)
- [ ] After merge, verify Dependabot picks up the config (Insights > Dependency graph > Dependabot) and opens initial PRs as needed