### PR TITLE
Preserve `prefetched_relations` through `RelatedSet` and `ManyToManySet` clones

### DIFF
--- a/spec/marten/db/query/related_set_spec.cr
+++ b/spec/marten/db/query/related_set_spec.cr
@@ -159,4 +159,32 @@ describe Marten::DB::Query::RelatedSet do
       qset[0].get_related_object_variable(:author).should be_nil
     end
   end
+
+  describe "#prefetch with chained operations" do
+    it "preserves prefetched_relations through #order" do
+      user_1 = TestUser.create!(username: "jd1", email: "jd1@example.com", first_name: "John", last_name: "Doe")
+      user_2 = TestUser.create!(username: "jd2", email: "jd2@example.com", first_name: "John", last_name: "Doe")
+
+      post_1 = Post.create!(author: user_1, title: "Post 1")
+      Post.create!(author: user_2, title: "Post 2")
+      post_3 = Post.create!(author: user_1, title: "Post 3")
+
+      qset = Marten::DB::Query::RelatedSet(Post).new(user_1, "author_id").prefetch(:author).order(:title)
+
+      results = qset.to_a
+      results.should eq [post_1, post_3]
+      results.each do |post|
+        post.get_related_object_variable(:author).should eq user_1
+      end
+    end
+
+    it "preserves prefetched_relations through #filter" do
+      user = TestUser.create!(username: "jd1", email: "jd1@example.com", first_name: "John", last_name: "Doe")
+      Post.create!(author: user, title: "Post 1")
+
+      qset = Marten::DB::Query::RelatedSet(Post).new(user, "author_id").prefetch(:author).filter(title: "Post 1")
+
+      qset.to_a.first.not_nil!.get_related_object_variable(:author).should eq user
+    end
+  end
 end

--- a/src/marten/db/model/querying.cr
+++ b/src/marten/db/model/querying.cr
@@ -1177,9 +1177,18 @@ module Marten
                   @instance : Marten::DB::Model,
                   @related_field_id : ::String,
                   query : Marten::DB::Query::SQL::Query({{ @type }})? = nil,
-                  @assign_related : ::Bool = false
+                  @assign_related : ::Bool = false,
+                  @prefetched_relations = [] of ::String,
+                  @custom_query_sets = {} of ::String => Marten::DB::Query::Set::Any,
                 )
-                  super(@instance, @related_field_id, query, @assign_related)
+                  super(
+                    @instance,
+                    @related_field_id,
+                    query,
+                    @assign_related,
+                    @prefetched_relations,
+                    @custom_query_sets,
+                  )
                 end
 
                 {% for queryset_id, block in MODEL_SCOPES[:custom] %}
@@ -1193,7 +1202,9 @@ module Marten
                     instance: @instance,
                     related_field_id: @related_field_id,
                     query: other_query.nil? ? @query.clone : other_query.not_nil!,
-                    assign_related: @assign_related
+                    assign_related: @assign_related,
+                    prefetched_relations: prefetched_relations,
+                    custom_query_sets: custom_query_sets,
                   )
                 end
               end
@@ -1205,7 +1216,9 @@ module Marten
                   @through_related_name : ::String,
                   @through_model_from_field_id : ::String,
                   @through_model_to_field_id : ::String,
-                  query : Marten::DB::Query::SQL::Query({{ @type }})? = nil
+                  query : Marten::DB::Query::SQL::Query({{ @type }})? = nil,
+                  @prefetched_relations = [] of ::String,
+                  @custom_query_sets = {} of ::String => Marten::DB::Query::Set::Any,
                 )
                   super(
                     @instance,
@@ -1213,7 +1226,9 @@ module Marten
                     @through_related_name,
                     @through_model_from_field_id,
                     @through_model_to_field_id,
-                    query
+                    query,
+                    @prefetched_relations,
+                    @custom_query_sets,
                   )
                 end
 
@@ -1230,7 +1245,9 @@ module Marten
                     through_related_name: @through_related_name,
                     through_model_from_field_id: @through_model_from_field_id,
                     through_model_to_field_id: @through_model_to_field_id,
-                    query: other_query.nil? ? @query.clone : other_query.not_nil!
+                    query: other_query.nil? ? @query.clone : other_query.not_nil!,
+                    prefetched_relations: prefetched_relations,
+                    custom_query_sets: custom_query_sets,
                   )
                 end
               end

--- a/src/marten/db/query/many_to_many_set.cr
+++ b/src/marten/db/query/many_to_many_set.cr
@@ -16,6 +16,8 @@ module Marten
           @through_model_from_field_id : String,
           @through_model_to_field_id : String,
           query : SQL::Query(M)? = nil,
+          @prefetched_relations = [] of String,
+          @custom_query_sets = {} of String => Set::Any,
         )
           @query = if query.nil?
                      q = SQL::Query(M).new
@@ -118,7 +120,9 @@ module Marten
             through_related_name: @through_related_name,
             through_model_from_field_id: @through_model_from_field_id,
             through_model_to_field_id: @through_model_to_field_id,
-            query: other_query.nil? ? @query.clone : other_query.not_nil!
+            query: other_query.nil? ? @query.clone : other_query.not_nil!,
+            prefetched_relations: prefetched_relations,
+            custom_query_sets: custom_query_sets,
           )
         end
 

--- a/src/marten/db/query/related_set.cr
+++ b/src/marten/db/query/related_set.cr
@@ -10,6 +10,8 @@ module Marten
           @related_field_id : String,
           query : SQL::Query(M)? = nil,
           @assign_related : ::Bool = false,
+          @prefetched_relations = [] of String,
+          @custom_query_sets = {} of String => Set::Any,
         )
           @query = if query.nil?
                      q = SQL::Query(M).new
@@ -37,7 +39,9 @@ module Marten
             instance: @instance,
             related_field_id: @related_field_id,
             query: other_query.nil? ? @query.clone : other_query.not_nil!,
-            assign_related: @assign_related
+            assign_related: @assign_related,
+            prefetched_relations: prefetched_relations,
+            custom_query_sets: custom_query_sets,
           )
         end
 


### PR DESCRIPTION
### Background: 

`Marten::DB::Query::Set#prefetch` returns a cloned queryset whose `prefetched_relations` collection is then updated in place. For the top-level `Set` this works because `Set#clone` forwards `prefetched_relations` (and `custom_query_sets`) to the new instance, so any subsequent chained method (e.g. `.order`, `.filter`, `.exclude`) carries the prefetch state forward and `#fetch` ultimately runs the prefetcher.

### Issue:

`RelatedSet` and `ManyToManySet` are different in two ways:

1. Their `#initialize` overrides do not accept `prefetched_relations` or `custom_query_sets` kwargs (the parent `Set#initialize` does), so newly-constructed instances always start with empty state.

2. Their `#clone` overrides construct a new instance without forwarding either field.

The result is that calling `#prefetch` on a `RelatedSet` (e.g. via a reverse many-to-one accessor like `user.posts`) appears to work but any chained method that calls `#clone` strips it. 

The next call to `#fetch` finds an empty `prefetched_relations`, skips the prefetcher entirely, and relation accessors on each returned record fall back to N+1 

```crystal
# Each post.author triggers a SELECT because the .order clone
# stripped the prefetch.
user.posts.prefetch(:author).order(:created_at).each { |p| p.author }
```

The macro-generated `<Model>::RelatedQuerySet` and `<Model>::ManyToManyQuerySet` in `model/querying.cr` have the same pair of overrides and inherit the bug.

### Fix:

This commit threads both fields through `#initialize` and `#clone` on:

- `Marten::DB::Query::RelatedSet`
- `Marten::DB::Query::ManyToManySet`
- `<Model>::RelatedQuerySet` (generated)
- `<Model>::ManyToManyQuerySet` (generated)

so prefetch state survives regardless of chain order.
