### PR TITLE
Update installation guide for brew 6 tap trust

### DIFF
--- a/docs/docs/getting-started/installation.md
+++ b/docs/docs/getting-started/installation.md
@@ -56,6 +56,7 @@ On macOS or Linux, Marten can be installed using [Homebrew](https://brew.sh/) (a
 
 ```bash
 brew tap martenframework/marten
+brew trust martenframework/marten
 brew install marten
 ```
 


### PR DESCRIPTION
It seems that starting in homebrew 6, taps must be marked as trusted. Homebrew seems to self update, so I think it will impact almost everyone (since older setups will have updated).

This appears to be the main info for it https://docs.brew.sh/Tap-Trust