### PR TITLE
Fix Lint/RedundantBegin in Template::Engine#get_template

### DIFF
--- a/src/marten/template/engine.cr
+++ b/src/marten/template/engine.cr
@@ -13,10 +13,8 @@ module Marten
       # Returns the first compiled template matching the given template name.
       def get_template(template_name : String) : Template
         @loaders.each do |loader|
-          begin
-            return loader.get_template(template_name)
-          rescue Errors::TemplateNotFound
-          end
+          return loader.get_template(template_name)
+        rescue Errors::TemplateNotFound
         end
 
         raise Errors::TemplateNotFound.new("Template #{template_name} could not be found")


### PR DESCRIPTION
The `begin`/`end` block inside `Template::Engine#get_template` is redundant: Crystal supports `rescue` directly at the block level. Removing it resolves the `Lint/RedundantBegin` offense (correctable) currently reported by ameba 1.7.0-dev, which fails the `QA checks` job.

```crystal
@loaders.each do |loader|
  return loader.get_template(template_name)
rescue Errors::TemplateNotFound
end
```

Behaviour is unchanged. `crystal tool format` applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)