### PR TITLE
Add support for raw update queries

### DIFF
--- a/spec/marten/db/query/set_spec.cr
+++ b/spec/marten/db/query/set_spec.cr
@@ -3678,6 +3678,57 @@ describe Marten::DB::Query::Set do
       user_3.is_admin.should be_falsey
     end
 
+    it "allows to update records using a raw SQL expression" do
+      user = TestUser.create!(username: "abc", email: "abc@example.com", first_name: "John", last_name: "Doe")
+
+      qset = Marten::DB::Query::Set(TestUser).new
+
+      qset.filter(username: "abc").update("first_name = last_name").should eq 1
+
+      user.reload
+      user.first_name.should eq "Doe"
+    end
+
+    it "allows to use positional parameters in raw SQL update expressions" do
+      user = TestUser.create!(
+        username: "abc",
+        email: "abc@example.com",
+        first_name: "John",
+        last_name: "Doe"
+      )
+
+      qset = Marten::DB::Query::Set(TestUser).new
+
+      qset.filter(username: "abc").update("first_name = ?", "Updated").should eq 1
+
+      user.reload
+      user.first_name.should eq "Updated"
+    end
+
+    it "allows to use named parameters in raw SQL update expressions" do
+      user = TestUser.create!(
+        username: "abc",
+        email: "abc@example.com",
+        first_name: "John",
+        last_name: "Doe"
+      )
+
+      qset = Marten::DB::Query::Set(TestUser).new
+
+      qset.filter(username: "abc").update("first_name = :name", name: "Updated").should eq 1
+
+      user.reload
+      user.first_name.should eq "Updated"
+    end
+
+    it "rejects an empty raw SQL update expression" do
+      qset = Marten::DB::Query::Set(TestUser).new
+
+      expect_raises(Marten::DB::Errors::UnmetQuerySetCondition, "Raw updates cannot be empty") do
+        qset.update("")
+      end
+    end
+
     it "returns 0 if no rows were affected by the updated" do
       user_1 = TestUser.create!(username: "abc", email: "abc@example.com", first_name: "John", last_name: "Doe")
       user_2 = TestUser.create!(username: "ghi", email: "ghi@example.com", first_name: "John", last_name: "Bar")

--- a/src/marten/db/query/set.cr
+++ b/src/marten/db/query/set.cr
@@ -1535,6 +1535,51 @@ module Marten
           @query.to_sql
         end
 
+        # Updates all the records matched by the current query set using the passed raw SQL expression.
+        def update(raw_update : String)
+          update(raw_update, [] of ::DB::Any)
+        end
+
+        # Updates all the records matched by the current query set using a raw SQL expression and positional parameters.
+        def update(raw_update : String, *args)
+          update(raw_update, args.to_a)
+        end
+
+        # Updates all the records matched by the current query set using a raw SQL expression and named parameters.
+        def update(raw_update : String, **kwargs)
+          update(raw_update, kwargs.to_h)
+        end
+
+        # Updates all the records matched by the current query set using a raw SQL expression and positional parameters.
+        def update(raw_update : String, params : Array)
+          raise_empty_raw_update if raw_update.empty?
+
+          raw_params = [] of ::DB::Any
+          raw_params += params
+
+          qs = clone
+          updated_count = qs.query.update_with(raw_update, raw_params)
+
+          reset_result_cache
+
+          updated_count
+        end
+
+        # Updates all the records matched by the current query set using a raw SQL expression and named parameters.
+        def update(raw_update : String, params : Hash | NamedTuple)
+          raise_empty_raw_update if raw_update.empty?
+
+          raw_params = {} of String => ::DB::Any
+          params.each { |k, v| raw_params[k.to_s] = v }
+
+          qs = clone
+          updated_count = qs.query.update_with(raw_update, raw_params)
+
+          reset_result_cache
+
+          updated_count
+        end
+
         # Updates all the records matched by the current query set with the passed values.
         #
         # This method allows to update all the records that are matched by the current query set with a hash or a named
@@ -1758,6 +1803,10 @@ module Marten
 
         private def raise_empty_raw_predicate
           raise Errors::UnmetQuerySetCondition.new("Raw predicates cannot be empty")
+        end
+
+        private def raise_empty_raw_update
+          raise Errors::UnmetQuerySetCondition.new("Raw updates cannot be empty")
         end
 
         private def raise_negative_indexes_not_supported

--- a/src/marten/db/query/sql/query.cr
+++ b/src/marten/db/query/sql/query.cr
@@ -525,6 +525,17 @@ module Marten
             rows_affected.not_nil!
           end
 
+          def update_with(raw_update : String, params : Array(::DB::Any) | Hash(String, ::DB::Any))
+            sql, parameters = build_raw_update_query(raw_update, params)
+
+            connection.open do |db|
+              result = db.exec(sql, args: parameters)
+              result.rows_affected
+            end
+          rescue Errors::EmptyResults
+            0
+          end
+
           private MATCH_ALL_PREDICATE = "1=1"
 
           private def build_annotations
@@ -851,6 +862,47 @@ module Marten
                       s << "UPDATE"
                       s << table_name
                       s << "SET #{column_names}"
+                      s << where_clause
+                      s << group_by
+                      s << having_clause
+                    end
+                  end
+
+            {sql, final_parameters}
+          end
+
+          private def build_raw_update_query(raw_update, raw_parameters)
+            update_clause, update_parameters = filtering_clause_and_parameters(
+              PredicateNode.new(raw_predicate: raw_update, params: raw_parameters)
+            )
+            update_parameters = update_parameters.not_nil!
+            where_clause, having_clause, filter_parameters =
+              where_and_having_clauses_and_parameters(update_parameters.size)
+
+            final_parameters = update_parameters
+            final_parameters += filter_parameters if !filter_parameters.nil?
+
+            sql = if !filter_parameters.nil? && (!@joins.empty? || !parent_model_joins.empty?)
+                    build_sql do |s|
+                      s << "UPDATE"
+                      s << table_name
+                      s << "SET #{update_clause}"
+                      s << "WHERE #{Model.db_table}.#{Model.pk_field.db_column!} IN ("
+                      s << "  SELECT * FROM ("
+                      s << "    SELECT DISTINCT #{Model.db_table}.#{Model.pk_field.db_column!}"
+                      s << "    FROM #{table_name}"
+                      s << build_joins
+                      s << where_clause
+                      s << group_by
+                      s << having_clause
+                      s << "  ) subquery"
+                      s << ")"
+                    end
+                  else
+                    build_sql do |s|
+                      s << "UPDATE"
+                      s << table_name
+                      s << "SET #{update_clause}"
                       s << where_clause
                       s << group_by
                       s << having_clause


### PR DESCRIPTION
## Summary

- I added raw `SET` expression overloads to query set updates.
- I added positional and named parameter support while preserving parameter offsets for filtered updates.
- I added regression coverage for direct expressions, both parameter styles, and empty expressions.

## Validation

- `crystal spec ./spec/marten/db/query/set_spec.cr --error-trace` — 325 examples, 0 failures
- `make qa_crystal` — formatter passed; 1,328 files inspected by Ameba with 0 failures
- `git diff --check`

I also started the full `make tests` suite locally, but it exceeded the 10-minute local execution limit. The focused query set suite and the complete Crystal QA checks passed; the full database matrix is deferred to CI.

Fixes #390
