### PR TITLE
Fix routes nested under a translated sub-map reversing to the default-locale path

### DIFF
--- a/docs/docs/the-marten-project/release-notes/0.7.md
+++ b/docs/docs/the-marten-project/release-notes/0.7.md
@@ -233,6 +233,10 @@ Please refer to the [Whitespace control](../../templates/introduction.md#whitesp
 
 * Improve thread-safety of the [`Marten::Cache::Store::Memory`](pathname:///api/dev/Marten/Cache/Store/Memory.html) cache store, making it safer to run Marten applications with Crystal's multi-threading support.
 
+## Bug fixes
+
+* Fix routes nested under a sub-map mounted on a [translated path](../../i18n/localized-routes.md) reversing to the default-locale path. Reversed URLs for such routes could not be resolved when a non-default locale was active.
+
 ## Backward incompatible changes
 
 ### Handlers and HTTP

--- a/spec/marten/routing/map_spec.cr
+++ b/spec/marten/routing/map_spec.cr
@@ -96,6 +96,25 @@ describe Marten::Routing::Match do
       map.path(Marten::Routing::TranslatedPath.new("routes.foo_bar"), sub_map, name: "included")
 
       map.reverse("included:baz").should eq "/foo/bar/baz"
+
+      I18n.with_locale(:fr) do
+        map.reverse("included:baz").should eq "/foo-french/bar-french/baz"
+      end
+    end
+
+    it "can be used for an included route with a translated path when the map is mounted on a non-translated path" do
+      map = Marten::Routing::Map.new
+
+      sub_map = Marten::Routing::Map.draw do
+        path(Marten::Routing::TranslatedPath.new("routes.foo_bar"), Marten::Handlers::Base, name: "baz")
+      end
+      map.path("/included", sub_map, name: "included")
+
+      map.reverse("included:baz").should eq "/included/foo/bar"
+
+      I18n.with_locale(:fr) do
+        map.reverse("included:baz").should eq "/included/foo-french/bar-french"
+      end
     end
 
     it "raises if the inserted rule is an empty string" do
@@ -142,6 +161,42 @@ describe Marten::Routing::Match do
         I18n.with_locale(:fr) do
           map.reverse("foo_bar").should eq "/fr/foo-french/bar-french"
           map.reverse("foo_bar_with_args", param1: 42, param2: "hello-world").should eq "/fr/foo/42/bar/hello-world"
+        end
+      end
+
+      it "allows to define localized routes for an included map mounted on a translated path" do
+        map = Marten::Routing::Map.new
+        map.exposed_root = true
+
+        sub_map = Marten::Routing::Map.draw do
+          path("/baz", Marten::Handlers::Base, name: "baz")
+        end
+
+        map.localized do
+          path t("routes.foo_bar"), sub_map, name: "included"
+        end
+
+        map.reverse("included:baz").should eq "/en/foo/bar/baz"
+
+        I18n.with_locale(:fr) do
+          map.reverse("included:baz").should eq "/fr/foo-french/bar-french/baz"
+        end
+      end
+
+      it "ensures that localized routes of an included map resolve what they reverse" do
+        map = Marten::Routing::Map.new
+        map.exposed_root = true
+
+        sub_map = Marten::Routing::Map.draw do
+          path("/baz", Marten::Handlers::Base, name: "baz")
+        end
+
+        map.localized do
+          path t("routes.foo_bar"), sub_map, name: "included"
+        end
+
+        I18n.with_locale(:fr) do
+          map.resolve(map.reverse("included:baz")).handler.should eq Marten::Handlers::Base
         end
       end
     end

--- a/spec/marten/routing/reverser_spec.cr
+++ b/spec/marten/routing/reverser_spec.cr
@@ -149,6 +149,58 @@ describe Marten::Routing::Reverser do
         }
       )
     end
+
+    it "keeps the localized paths when the other reverser is not associated with a translated path" do
+      reverser = Marten::Routing::Reverser.new(
+        "path:name",
+        {
+          nil  => "/test",
+          "en" => "/this-is-a-test",
+          "fr" => "/ceci-est-un-test",
+        } of String? => String
+      )
+
+      combined = reverser.combine(Marten::Routing::Reverser.new("other:name", "/other"))
+
+      combined.exposed_path_for_interpolations.should eq(
+        {
+          nil  => "/test/other",
+          "en" => "/this-is-a-test/other",
+          "fr" => "/ceci-est-un-test/other",
+        } of String? => String
+      )
+    end
+
+    it "keeps the localized paths when the current reverser is not associated with a translated path" do
+      reverser = Marten::Routing::Reverser.new("path:name", "/test")
+
+      combined = reverser.combine(
+        Marten::Routing::Reverser.new(
+          "other:name",
+          {
+            nil  => "/other",
+            "en" => "/this-is-another-test",
+            "fr" => "/ceci-est-un-autre-test",
+          } of String? => String
+        )
+      )
+
+      combined.exposed_path_for_interpolations.should eq(
+        {
+          nil  => "/test/other",
+          "en" => "/test/this-is-another-test",
+          "fr" => "/test/ceci-est-un-autre-test",
+        } of String? => String
+      )
+    end
+
+    it "returns the expected reverser when none of the reversers are associated with translated paths" do
+      reverser = Marten::Routing::Reverser.new("path:name", "/test")
+
+      combined = reverser.combine(Marten::Routing::Reverser.new("other:name", "/other"))
+
+      combined.exposed_path_for_interpolations.should eq({nil => "/test/other"} of String? => String)
+    end
   end
 
   describe "#name" do

--- a/src/marten/routing/reverser.cr
+++ b/src/marten/routing/reverser.cr
@@ -41,10 +41,14 @@ module Marten
         new_name = name.empty? ? other.name : "#{name}:#{other.name}"
 
         new_path_for_interpolations = Hash(String?, String).new
-        @path_for_interpolations.each do |locale, path_for_interpolation|
-          next if other.path_for_interpolations[locale]?.nil?
+        (@path_for_interpolations.keys | other.path_for_interpolations.keys).each do |locale|
+          # Reversers that are not associated with translated paths only carry a default locale path, so both sides
+          # fall back to it in order to not discard the locales contributed by the other side.
+          path_for_interpolation = @path_for_interpolations[locale]? || @path_for_interpolations[nil]?
+          other_path_for_interpolation = other.path_for_interpolations[locale]? || other.path_for_interpolations[nil]?
+          next if path_for_interpolation.nil? || other_path_for_interpolation.nil?
 
-          new_path_for_interpolations[locale] = path_for_interpolation + other.path_for_interpolations[locale]
+          new_path_for_interpolations[locale] = path_for_interpolation + other_path_for_interpolation
         end
 
         Reverser.new(


### PR DESCRIPTION
Routes nested under a sub-map mounted on a translated path reverse to the default-locale path, while still receiving the active locale's prefix:

```crystal
Marten.routes.draw do
  localized(prefix_default_locale: false) do
    path t("routes.articles"), ARTICLE_ROUTES, name: "articles"   # ARTICLE_ROUTES: path "/create", …, name: "create"
  end
end

I18n.with_locale(:en) { Marten.routes.reverse("articles:create") }
# => "/en/artikel/create"   English prefix, German path — raises NoResolveMatch when resolved
```

`#reverse` and `#resolve` disagree, so every {% url %} under the sub-map emits a link that 404s in non-default locales. It fails silently and only outside the default locale.